### PR TITLE
Issue##7 Belong 기능 구현

### DIFF
--- a/src/main/java/park/brothers/runwith_back/domain/Belong/controller/BelongController.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Belong/controller/BelongController.java
@@ -1,0 +1,85 @@
+package park.brothers.runwith_back.domain.Belong.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.*;
+import park.brothers.runwith_back.common.Response.ValidationErrorUtils;
+import park.brothers.runwith_back.domain.Belong.dto.Request.ChangeLeaderRequestDto;
+import park.brothers.runwith_back.domain.Belong.dto.Request.JoinGroupRequestDto;
+import park.brothers.runwith_back.domain.Belong.dto.Request.LeaveGroupRequestDto;
+import park.brothers.runwith_back.domain.Belong.service.BelongService;
+import park.brothers.runwith_back.domain.Group.dto.GetGroupResponseDto;
+import park.brothers.runwith_back.domain.Runner.dto.Response.GetRunnerResponseDto;
+
+import java.util.List;
+
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/belongs")
+public class BelongController {
+
+    private final BelongService belongService;
+
+    //그룹 참여 api
+    @PostMapping
+    public ResponseEntity<Object> save(@RequestBody @Valid JoinGroupRequestDto joinGroupRequestDto, BindingResult bindingResult){
+        if(bindingResult.hasErrors()){
+            return ValidationErrorUtils.handleValidationErrors(bindingResult);
+        }
+
+        belongService.joinGroup(joinGroupRequestDto);
+
+        return ResponseEntity.status(HttpStatus.OK).body(joinGroupRequestDto);
+
+    }
+
+    //그룹 탈퇴 api
+    @DeleteMapping
+    public ResponseEntity<Object> leave(@RequestBody @Valid LeaveGroupRequestDto leaveGroupRequestDto, BindingResult bindingResult){
+        if(bindingResult.hasErrors()){
+            return ValidationErrorUtils.handleValidationErrors(bindingResult);
+        }
+
+        belongService.leaveGroup(leaveGroupRequestDto);
+
+        return ResponseEntity.status(HttpStatus.OK).body(leaveGroupRequestDto);
+    }
+
+    //특정 runner가 속한 모든 그룹들을 응답 받는 api
+    @GetMapping("/runnerId={runnerId}")
+    public ResponseEntity<Object> getAllGroupsRunnerJoin(@PathVariable @Valid Long runnerId){
+        List<GetGroupResponseDto> groups = belongService.getAllGroupsRunnerJoin(runnerId);
+        return ResponseEntity.status(HttpStatus.OK).body(groups);
+    }
+
+    //특정 그룹에 속한 모든 runner들을 응답 받는 api
+    @GetMapping("/groupId={groupId}")
+    public ResponseEntity<Object> getAllRunnersInGroup(@PathVariable @Valid Long groupId){
+        List<GetRunnerResponseDto> runners = belongService.getAllRunnersInGroup(groupId);
+        return ResponseEntity.status(HttpStatus.OK).body(runners);
+    }
+
+    //그룹의 리더 변경 api
+    @PatchMapping("/leader")
+    public ResponseEntity<Object> changeLeader(@RequestBody @Valid ChangeLeaderRequestDto changeLeaderRequestDto, BindingResult bindingResult){
+        if(bindingResult.hasErrors()){
+            return ValidationErrorUtils.handleValidationErrors(bindingResult);
+        }
+
+        belongService.changeLeader(changeLeaderRequestDto);
+
+        return ResponseEntity.status(HttpStatus.OK).body(changeLeaderRequestDto);
+    }
+
+
+
+
+
+
+}

--- a/src/main/java/park/brothers/runwith_back/domain/Belong/controller/BelongController.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Belong/controller/BelongController.java
@@ -12,7 +12,7 @@ import park.brothers.runwith_back.domain.Belong.dto.Request.ChangeLeaderRequestD
 import park.brothers.runwith_back.domain.Belong.dto.Request.JoinGroupRequestDto;
 import park.brothers.runwith_back.domain.Belong.dto.Request.LeaveGroupRequestDto;
 import park.brothers.runwith_back.domain.Belong.service.BelongService;
-import park.brothers.runwith_back.domain.Group.dto.GetGroupResponseDto;
+import park.brothers.runwith_back.domain.Group.dto.Response.GetGroupResponseDto;
 import park.brothers.runwith_back.domain.Runner.dto.Response.GetRunnerResponseDto;
 
 import java.util.List;

--- a/src/main/java/park/brothers/runwith_back/domain/Belong/dto/Request/ChangeLeaderRequestDto.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Belong/dto/Request/ChangeLeaderRequestDto.java
@@ -1,0 +1,17 @@
+package park.brothers.runwith_back.domain.Belong.dto.Request;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Data;
+
+@Data
+public class ChangeLeaderRequestDto {
+
+    @NotEmpty
+    Long beforeLeaderId;
+
+    @NotEmpty
+    Long afterLeaderId;
+
+    @NotEmpty
+    Long groupId;
+}

--- a/src/main/java/park/brothers/runwith_back/domain/Belong/dto/Request/JoinGroupRequestDto.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Belong/dto/Request/JoinGroupRequestDto.java
@@ -1,0 +1,20 @@
+package park.brothers.runwith_back.domain.Belong.dto.Request;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Data;
+
+@Data
+public class JoinGroupRequestDto {
+
+    @NotEmpty
+    Long runnerId;
+
+    @NotEmpty
+    Long groupId;
+
+    @NotEmpty
+    String nickname;
+
+    @NotEmpty
+    Boolean isLeader;
+}

--- a/src/main/java/park/brothers/runwith_back/domain/Belong/dto/Request/LeaveGroupRequestDto.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Belong/dto/Request/LeaveGroupRequestDto.java
@@ -1,0 +1,16 @@
+package park.brothers.runwith_back.domain.Belong.dto.Request;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Data;
+
+@Data
+public class LeaveGroupRequestDto {
+
+    @NotEmpty
+    Long runnerId;
+
+    @NotEmpty
+    Long groupId;
+
+}
+

--- a/src/main/java/park/brothers/runwith_back/domain/Belong/entity/Belong.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Belong/entity/Belong.java
@@ -1,0 +1,39 @@
+package park.brothers.runwith_back.domain.Belong.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import park.brothers.runwith_back.domain.Group.entity.Group;
+import park.brothers.runwith_back.domain.Runner.entity.Runner;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Setter
+@Getter
+@Table(name = "belongs")
+public class Belong {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY) //Belong을 조회할 때 Belog만 조회하고, Runner는 나중에 조회(지연 로딩)
+    @JoinColumn(name = "runners")
+    private Runner runner;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "groups")
+    private Group group;
+
+    @Column(nullable = false)
+    private boolean isLeader;
+
+    @Column(nullable = false)
+    private String nickname;
+
+    @CreationTimestamp
+    @Column
+    private LocalDateTime joinAt;
+}

--- a/src/main/java/park/brothers/runwith_back/domain/Belong/repository/BelongRepository.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Belong/repository/BelongRepository.java
@@ -1,0 +1,22 @@
+package park.brothers.runwith_back.domain.Belong.repository;
+
+import park.brothers.runwith_back.domain.Belong.entity.Belong;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface BelongRepository {
+    Optional<Belong> findByRunnerIdAndGroupId(Long runnerId, Long groupId);
+
+    Optional<Object> findByGroupIdAndNickname(Long groupId, String nickname);
+
+    void save(Belong belong);
+
+    void deleteByRunnerIdAndGroupId(Long runnerId, Long groupId);
+
+    List<Belong> findByRunnerId(Long runnerId);
+
+    List<Belong> findByGroupId(Long groupId);
+
+    void changeIsLeader(Long runnerId, Long groupId, boolean isLeader);
+}

--- a/src/main/java/park/brothers/runwith_back/domain/Belong/repository/JPABelongRepository.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Belong/repository/JPABelongRepository.java
@@ -1,0 +1,82 @@
+package park.brothers.runwith_back.domain.Belong.repository;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+import park.brothers.runwith_back.domain.Belong.entity.Belong;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@Slf4j
+@Primary
+@Transactional
+@RequiredArgsConstructor
+public class JPABelongRepository implements BelongRepository{
+
+    private final EntityManager em;
+
+    //러너 id와 group id로 belong객체 찾기
+    @Override
+    public Optional<Belong> findByRunnerIdAndGroupId(Long runnerId, Long groupId) {
+         return Optional.ofNullable(em.createQuery("select b from Belong b where b.runner.id = :runnerId and b.group.id = :groupId", Belong.class)
+                 .setParameter("runnerId", runnerId)
+                 .setParameter("groupId", groupId)
+                 .getSingleResult());
+    }
+
+    //그룹id와 닉네임으로 객체 찾기
+    @Override
+    public Optional<Object> findByGroupIdAndNickname(Long groupId, String nickname) {
+        return Optional.ofNullable(
+                em.createQuery("select b from Belong b where b.group.id = :groupId and b.nickname = :nickname")
+                        .setParameter("groupId", groupId)
+                        .setParameter("nickname", nickname)
+                        .getSingleResultOrNull()
+        );
+    }
+
+    @Override
+    public void save(Belong belong) {
+        em.persist(belong);
+    }
+
+    @Override
+    public void deleteByRunnerIdAndGroupId(Long runnerId, Long groupId) {
+        Optional<Belong> belong = Optional.ofNullable(em.createQuery("select b from Belong b where b.runner.id = :runnerId and b.group.id = :groupId", Belong.class)
+                .setParameter("runnerId", runnerId)
+                .setParameter("groupId", groupId)
+                .getSingleResult());
+        if(belong.isPresent()){
+            em.remove(belong);
+        }
+    }
+
+    @Override
+    public List<Belong> findByRunnerId(Long runnerId) {
+        return em.createQuery("select b from Belong b where b.runner.id = :runnerId", Belong.class)
+                        .setParameter("runnerId", runnerId)
+                        .getResultList();
+    }
+
+    @Override
+    public List<Belong> findByGroupId(Long groupId) {
+        return em.createQuery("select b from Belong b where b.group.id = :groupId", Belong.class)
+                .setParameter("groupId", groupId)
+                .getResultList();
+    }
+
+    @Override
+    public void changeIsLeader(Long runnerId, Long groupId, boolean isLeader) {
+        Belong belong = em.createQuery("select b from Belong b where b.runner.id = :runnerId and b.group.id = :groupId", Belong.class)
+                .setParameter("runnerId", runnerId)
+                .setParameter("groupId", groupId)
+                .getSingleResult();
+
+        belong.setLeader(isLeader);
+    }
+}

--- a/src/main/java/park/brothers/runwith_back/domain/Belong/service/BelongService.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Belong/service/BelongService.java
@@ -1,0 +1,22 @@
+package park.brothers.runwith_back.domain.Belong.service;
+
+import jakarta.validation.Valid;
+import park.brothers.runwith_back.domain.Belong.dto.Request.ChangeLeaderRequestDto;
+import park.brothers.runwith_back.domain.Belong.dto.Request.JoinGroupRequestDto;
+import park.brothers.runwith_back.domain.Belong.dto.Request.LeaveGroupRequestDto;
+import park.brothers.runwith_back.domain.Group.dto.GetGroupResponseDto;
+import park.brothers.runwith_back.domain.Runner.dto.Response.GetRunnerResponseDto;
+
+import java.util.List;
+
+public interface BelongService {
+    void joinGroup(@Valid JoinGroupRequestDto joinGroupRequestDto);
+
+    void leaveGroup(@Valid LeaveGroupRequestDto leaveGroupRequestDto);
+
+    List<GetGroupResponseDto> getAllGroupsRunnerJoin(@Valid Long runnerId);
+
+    List<GetRunnerResponseDto> getAllRunnersInGroup(@Valid Long groupId);
+
+    void changeLeader(@Valid ChangeLeaderRequestDto changeLeaderRequestDto);
+}

--- a/src/main/java/park/brothers/runwith_back/domain/Belong/service/BelongService.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Belong/service/BelongService.java
@@ -4,7 +4,7 @@ import jakarta.validation.Valid;
 import park.brothers.runwith_back.domain.Belong.dto.Request.ChangeLeaderRequestDto;
 import park.brothers.runwith_back.domain.Belong.dto.Request.JoinGroupRequestDto;
 import park.brothers.runwith_back.domain.Belong.dto.Request.LeaveGroupRequestDto;
-import park.brothers.runwith_back.domain.Group.dto.GetGroupResponseDto;
+import park.brothers.runwith_back.domain.Group.dto.Response.GetGroupResponseDto;
 import park.brothers.runwith_back.domain.Runner.dto.Response.GetRunnerResponseDto;
 
 import java.util.List;

--- a/src/main/java/park/brothers/runwith_back/domain/Belong/service/Version1BelongService.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Belong/service/Version1BelongService.java
@@ -1,0 +1,109 @@
+package park.brothers.runwith_back.domain.Belong.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import park.brothers.runwith_back.domain.Belong.dto.Request.ChangeLeaderRequestDto;
+import park.brothers.runwith_back.domain.Belong.dto.Request.JoinGroupRequestDto;
+import park.brothers.runwith_back.domain.Belong.dto.Request.LeaveGroupRequestDto;
+import park.brothers.runwith_back.domain.Belong.entity.Belong;
+import park.brothers.runwith_back.domain.Belong.repository.BelongRepository;
+import park.brothers.runwith_back.domain.Group.dto.GetGroupResponseDto;
+import park.brothers.runwith_back.domain.Group.entity.Group;
+import park.brothers.runwith_back.domain.Group.repository.GroupRepository;
+import park.brothers.runwith_back.domain.Runner.dto.Response.GetRunnerResponseDto;
+import park.brothers.runwith_back.domain.Runner.entity.Runner;
+import park.brothers.runwith_back.domain.Runner.repository.RunnerRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class Version1BelongService implements BelongService{
+
+    private final BelongRepository belongRepository;
+    private final RunnerRepository runnerRepository;
+    private final GroupRepository groupRepository;
+
+    // 그룹 참여
+    @Override
+    public void joinGroup(JoinGroupRequestDto joinGroupRequestDto) {
+        Long runnerId = joinGroupRequestDto.getRunnerId();
+        Long groupId = joinGroupRequestDto.getGroupId();
+        String nickname = joinGroupRequestDto.getNickname();
+
+        //이미 가입한 그룹이 아니면 가입
+        if (belongRepository.findByRunnerIdAndGroupId(runnerId, groupId).isPresent()) {
+            throw new IllegalStateException("이미 그룹에 가입되어 있습니다.");
+        }
+
+        // 닉네임 중복 확인
+        if (belongRepository.findByGroupIdAndNickname(groupId, nickname).isPresent()) {
+            throw new IllegalStateException("이미 사용 중인 닉네임입니다.");
+        }
+
+        // 엔티티 조회
+        Runner runner = runnerRepository.findById(runnerId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 러너입니다."));
+
+        Group group = groupRepository.findById(groupId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 그룹입니다."));
+
+        // 가입 처리
+        Belong belong = new Belong();
+        belong.setRunner(runner);
+        belong.setGroup(group);
+        belong.setLeader(false);
+        belong.setNickname(nickname);
+
+        belongRepository.save(belong);
+    }
+    
+    //그룹 탈퇴 기능
+    @Override
+    public void leaveGroup(LeaveGroupRequestDto leaveGroupRequestDto) {
+        Long groupId = leaveGroupRequestDto.getGroupId();
+        Long runnerId = leaveGroupRequestDto.getRunnerId();
+        
+        //그룹에 속해있으면 탈퇴 가능
+        if(belongRepository.findByRunnerIdAndGroupId(runnerId, groupId).isPresent()){
+            belongRepository.deleteByRunnerIdAndGroupId(runnerId, groupId);
+        }
+    }
+
+    //특정 러너가 속한 모든 그룹 가져오기
+    @Override
+    public List<GetGroupResponseDto> getAllGroupsRunnerJoin(Long runnerId) {
+        List<Belong> belongs = belongRepository.findByRunnerId(runnerId);
+        return belongs.stream()
+                .map(belong -> new GetGroupResponseDto(belong.getGroup().getId(), belong.getGroup().getName()))
+                .collect(Collectors.toList());
+    }
+
+    //특정 그룹에 속한 모든 러너들 가져오기
+    @Override
+    public List<GetRunnerResponseDto> getAllRunnersInGroup(Long groupId) {
+        List<Belong> belongs = belongRepository.findByGroupId(groupId);
+        return belongs.stream()
+                .map(belong -> new GetRunnerResponseDto(belong.getRunner().getId(), belong.getRunner().getName()))
+                .collect(Collectors.toList());
+    }
+
+    //특정 그룹의 리더 변경하기
+    @Override
+    public void changeLeader(ChangeLeaderRequestDto changeLeaderRequestDto) {
+        Long beforeLeaderId = changeLeaderRequestDto.getBeforeLeaderId();
+        Long afterLeaderId = changeLeaderRequestDto.getAfterLeaderId();
+        Long groupId = changeLeaderRequestDto.getGroupId();
+
+        //이전 리더가 리더인지 확인
+        Optional<Belong> belong = belongRepository.findByRunnerIdAndGroupId(beforeLeaderId, groupId);
+        if(belong.isPresent() && !belong.get().isLeader()){
+            throw new IllegalStateException("리더가 아닙니다.");
+        }
+
+        belongRepository.changeIsLeader(beforeLeaderId, groupId, false);
+        belongRepository.changeIsLeader(afterLeaderId, groupId, true);
+    }
+}

--- a/src/main/java/park/brothers/runwith_back/domain/Belong/service/Version1BelongService.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Belong/service/Version1BelongService.java
@@ -7,7 +7,7 @@ import park.brothers.runwith_back.domain.Belong.dto.Request.JoinGroupRequestDto;
 import park.brothers.runwith_back.domain.Belong.dto.Request.LeaveGroupRequestDto;
 import park.brothers.runwith_back.domain.Belong.entity.Belong;
 import park.brothers.runwith_back.domain.Belong.repository.BelongRepository;
-import park.brothers.runwith_back.domain.Group.dto.GetGroupResponseDto;
+import park.brothers.runwith_back.domain.Group.dto.Response.GetGroupResponseDto;
 import park.brothers.runwith_back.domain.Group.entity.Group;
 import park.brothers.runwith_back.domain.Group.repository.GroupRepository;
 import park.brothers.runwith_back.domain.Runner.dto.Response.GetRunnerResponseDto;

--- a/src/main/java/park/brothers/runwith_back/domain/Group/controller/GroupController.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Group/controller/GroupController.java
@@ -7,8 +7,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
-import park.brothers.runwith_back.domain.Group.dto.CreateGroupDto;
-import park.brothers.runwith_back.domain.Group.dto.GetGroupResponseDto;
+import park.brothers.runwith_back.domain.Group.dto.Request.CreateGroupRequestDto;
+import park.brothers.runwith_back.domain.Group.dto.Response.GetGroupResponseDto;
 import park.brothers.runwith_back.domain.Group.dto.Request.DeleteGroupRequestDto;
 import park.brothers.runwith_back.domain.Group.service.GroupService;
 import park.brothers.runwith_back.common.Response.ValidationErrorUtils;
@@ -24,14 +24,14 @@ public class GroupController {
     private final GroupService groupService;
 
     @PostMapping
-    public ResponseEntity<Object> save(@RequestBody @Valid CreateGroupDto createGroupDto, BindingResult bindingResult){ //BindingResult은 DTO만
+    public ResponseEntity<Object> save(@RequestBody @Valid CreateGroupRequestDto createGroupRequestDto, BindingResult bindingResult){ //BindingResult은 DTO만
         if (bindingResult.hasErrors()) {
             return ValidationErrorUtils.handleValidationErrors(bindingResult);
         }
 
-        groupService.save(createGroupDto);
+        groupService.save(createGroupRequestDto);
 
-        return ResponseEntity.status(HttpStatus.OK).body(createGroupDto);
+        return ResponseEntity.status(HttpStatus.OK).body(createGroupRequestDto);
     }
 
     @GetMapping("/{name}")

--- a/src/main/java/park/brothers/runwith_back/domain/Group/controller/GroupController.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Group/controller/GroupController.java
@@ -9,6 +9,7 @@ import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 import park.brothers.runwith_back.domain.Group.dto.CreateGroupDto;
 import park.brothers.runwith_back.domain.Group.dto.GetGroupResponseDto;
+import park.brothers.runwith_back.domain.Group.dto.Request.DeleteGroupRequestDto;
 import park.brothers.runwith_back.domain.Group.service.GroupService;
 import park.brothers.runwith_back.common.Response.ValidationErrorUtils;
 
@@ -45,9 +46,12 @@ public class GroupController {
         return ResponseEntity.status(HttpStatus.OK).body(groups);
     }
 
-    @DeleteMapping("/{id}")
-    public ResponseEntity<Object> deleteGroup(@PathVariable @Valid Long id) {
-        groupService.delete(id);
-        return ResponseEntity.status(HttpStatus.OK).body(id);
+    @DeleteMapping()
+    public ResponseEntity<Object> deleteGroup(@RequestBody @Valid DeleteGroupRequestDto deleteGroupRequestDto, BindingResult bindingResult) {
+        if(bindingResult.hasErrors()){
+            return ValidationErrorUtils.handleValidationErrors(bindingResult);
+        }
+        groupService.delete(deleteGroupRequestDto);
+        return ResponseEntity.status(HttpStatus.OK).body(deleteGroupRequestDto);
     }
 }

--- a/src/main/java/park/brothers/runwith_back/domain/Group/dto/CreateGroupDto.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Group/dto/CreateGroupDto.java
@@ -1,6 +1,7 @@
 package park.brothers.runwith_back.domain.Group.dto;
 
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.Getter;
 
@@ -9,4 +10,10 @@ import lombok.Getter;
 public class CreateGroupDto {
     @NotEmpty
     private String name;
+
+    @NotNull //Long에서는 NotNull을 사용해야 한다.
+    private Long runnerId;
+
+    @NotEmpty
+    private String nickname;
 }

--- a/src/main/java/park/brothers/runwith_back/domain/Group/dto/Request/CreateGroupRequestDto.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Group/dto/Request/CreateGroupRequestDto.java
@@ -1,4 +1,4 @@
-package park.brothers.runwith_back.domain.Group.dto;
+package park.brothers.runwith_back.domain.Group.dto.Request;
 
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
@@ -7,7 +7,7 @@ import lombok.Getter;
 
 @Data
 @Getter
-public class CreateGroupDto {
+public class CreateGroupRequestDto {
     @NotEmpty
     private String name;
 

--- a/src/main/java/park/brothers/runwith_back/domain/Group/dto/Request/DeleteGroupRequestDto.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Group/dto/Request/DeleteGroupRequestDto.java
@@ -1,0 +1,16 @@
+package park.brothers.runwith_back.domain.Group.dto.Request;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class DeleteGroupRequestDto {
+
+    @NotEmpty
+    private Long groupId;
+
+    @NotEmpty
+    private Long runnerId;
+}

--- a/src/main/java/park/brothers/runwith_back/domain/Group/dto/Response/GetGroupResponseDto.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Group/dto/Response/GetGroupResponseDto.java
@@ -1,4 +1,4 @@
-package park.brothers.runwith_back.domain.Group.dto;
+package park.brothers.runwith_back.domain.Group.dto.Response;
 
 import jakarta.validation.constraints.NotEmpty;
 import lombok.AllArgsConstructor;

--- a/src/main/java/park/brothers/runwith_back/domain/Group/repository/GroupRepository.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Group/repository/GroupRepository.java
@@ -3,6 +3,7 @@ package park.brothers.runwith_back.domain.Group.repository;
 
 import park.brothers.runwith_back.domain.Group.entity.Group;
 import java.util.List;
+import java.util.Optional;
 
 public interface GroupRepository {
     void save(Group group);
@@ -16,4 +17,6 @@ public interface GroupRepository {
     List<Group> findBySimilarName(String name);
 
     Group getById(Long id);
+
+    Optional<Group> findById(Long groupId);
 }

--- a/src/main/java/park/brothers/runwith_back/domain/Group/repository/JPAGroupRepository.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Group/repository/JPAGroupRepository.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 import park.brothers.runwith_back.domain.Group.entity.Group;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 @Slf4j
@@ -52,5 +53,12 @@ public class JPAGroupRepository implements GroupRepository {
     @Override
     public Group getById(Long id) {
         return em.find(Group.class, id);
+    }
+
+    @Override
+    public Optional<Group> findById(Long id) {
+        return Optional.ofNullable(em.createQuery("select g from Group g where g.id = :id", Group.class)
+                .setParameter("id", id)
+                .getSingleResult());
     }
 }

--- a/src/main/java/park/brothers/runwith_back/domain/Group/service/GroupService.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Group/service/GroupService.java
@@ -2,6 +2,7 @@ package park.brothers.runwith_back.domain.Group.service;
 
 import park.brothers.runwith_back.domain.Group.dto.CreateGroupDto;
 import park.brothers.runwith_back.domain.Group.dto.GetGroupResponseDto;
+import park.brothers.runwith_back.domain.Group.dto.Request.DeleteGroupRequestDto;
 
 import java.util.List;
 
@@ -15,5 +16,5 @@ public interface GroupService {
 
     List<GetGroupResponseDto> getGroupsBySimilarName(String name);
 
-    void delete(Long id);
+    void delete(DeleteGroupRequestDto deleteGroupRequestDto);
 }

--- a/src/main/java/park/brothers/runwith_back/domain/Group/service/GroupService.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Group/service/GroupService.java
@@ -1,14 +1,14 @@
 package park.brothers.runwith_back.domain.Group.service;
 
-import park.brothers.runwith_back.domain.Group.dto.CreateGroupDto;
-import park.brothers.runwith_back.domain.Group.dto.GetGroupResponseDto;
+import park.brothers.runwith_back.domain.Group.dto.Request.CreateGroupRequestDto;
+import park.brothers.runwith_back.domain.Group.dto.Response.GetGroupResponseDto;
 import park.brothers.runwith_back.domain.Group.dto.Request.DeleteGroupRequestDto;
 
 import java.util.List;
 
 public interface GroupService {
 
-    void save(CreateGroupDto createGroupDto);
+    void save(CreateGroupRequestDto createGroupRequestDto);
 
     List<GetGroupResponseDto> getAllGroups();
 

--- a/src/main/java/park/brothers/runwith_back/domain/Group/service/Version1GroupService.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Group/service/Version1GroupService.java
@@ -4,8 +4,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import park.brothers.runwith_back.domain.Belong.entity.Belong;
 import park.brothers.runwith_back.domain.Belong.repository.BelongRepository;
-import park.brothers.runwith_back.domain.Group.dto.CreateGroupDto;
-import park.brothers.runwith_back.domain.Group.dto.GetGroupResponseDto;
+import park.brothers.runwith_back.domain.Group.dto.Request.CreateGroupRequestDto;
+import park.brothers.runwith_back.domain.Group.dto.Response.GetGroupResponseDto;
 import park.brothers.runwith_back.domain.Group.dto.Request.DeleteGroupRequestDto;
 import park.brothers.runwith_back.domain.Group.entity.Group;
 import park.brothers.runwith_back.domain.Group.repository.GroupRepository;
@@ -25,23 +25,23 @@ public class Version1GroupService implements GroupService {
     private final BelongRepository belongRepository;
 
     @Override
-    public void save(CreateGroupDto createGroupDto) {
-        Optional<Runner> runner = runnerRepository.findById(createGroupDto.getRunnerId());
+    public void save(CreateGroupRequestDto createGroupRequestDto) {
+        Optional<Runner> runner = runnerRepository.findById(createGroupRequestDto.getRunnerId());
 
-         if(groupRepository.findByName(createGroupDto.getName()) == null && runner.isPresent()){
+         if(groupRepository.findByName(createGroupRequestDto.getName()) == null && runner.isPresent()){
              //그룹 객체 생성
              Group group = new Group();
-             group.setName(createGroupDto.getName());
+             group.setName(createGroupRequestDto.getName());
              groupRepository.save(group);
 
              //그룹 가져오기
-             Group saved_group = groupRepository.findByName(createGroupDto.getName());
+             Group saved_group = groupRepository.findByName(createGroupRequestDto.getName());
 
              //이 그룹에 자기가 속했고, 리더임을 나타내는 Belong객체 생성
              Belong belong = new Belong();
              belong.setRunner(runner.get());
              belong.setGroup(saved_group);
-             belong.setNickname(createGroupDto.getNickname());
+             belong.setNickname(createGroupRequestDto.getNickname());
              belong.setLeader(true);
              belongRepository.save(belong);
          }

--- a/src/main/java/park/brothers/runwith_back/domain/Group/service/Version1GroupService.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Group/service/Version1GroupService.java
@@ -2,12 +2,18 @@ package park.brothers.runwith_back.domain.Group.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import park.brothers.runwith_back.domain.Belong.entity.Belong;
+import park.brothers.runwith_back.domain.Belong.repository.BelongRepository;
 import park.brothers.runwith_back.domain.Group.dto.CreateGroupDto;
 import park.brothers.runwith_back.domain.Group.dto.GetGroupResponseDto;
+import park.brothers.runwith_back.domain.Group.dto.Request.DeleteGroupRequestDto;
 import park.brothers.runwith_back.domain.Group.entity.Group;
 import park.brothers.runwith_back.domain.Group.repository.GroupRepository;
+import park.brothers.runwith_back.domain.Runner.entity.Runner;
+import park.brothers.runwith_back.domain.Runner.repository.RunnerRepository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -15,13 +21,29 @@ import java.util.stream.Collectors;
 public class Version1GroupService implements GroupService {
 
     private final GroupRepository groupRepository;
+    private final RunnerRepository runnerRepository;
+    private final BelongRepository belongRepository;
 
     @Override
     public void save(CreateGroupDto createGroupDto) {
-         if(groupRepository.findByName(createGroupDto.getName()) == null){
+        Optional<Runner> runner = runnerRepository.findById(createGroupDto.getRunnerId());
+
+         if(groupRepository.findByName(createGroupDto.getName()) == null && runner.isPresent()){
+             //그룹 객체 생성
              Group group = new Group();
              group.setName(createGroupDto.getName());
              groupRepository.save(group);
+
+             //그룹 가져오기
+             Group saved_group = groupRepository.findByName(createGroupDto.getName());
+
+             //이 그룹에 자기가 속했고, 리더임을 나타내는 Belong객체 생성
+             Belong belong = new Belong();
+             belong.setRunner(runner.get());
+             belong.setGroup(saved_group);
+             belong.setNickname(createGroupDto.getNickname());
+             belong.setLeader(true);
+             belongRepository.save(belong);
          }
     }
 
@@ -50,8 +72,19 @@ public class Version1GroupService implements GroupService {
     }
 
     @Override
-    public void delete(Long id) {
-        Group group = groupRepository.getById(id);
-        groupRepository.delete(group);
+    public void delete(DeleteGroupRequestDto deleteGroupRequestDto) {
+        Long groupId = deleteGroupRequestDto.getGroupId();
+        Long runnerId = deleteGroupRequestDto.getRunnerId();
+
+        Group group = groupRepository.getById(groupId);
+        Optional<Runner> runner = runnerRepository.findById(runnerId);
+        if(runner.isPresent()){
+            List<Belong> belongs = belongRepository.findByGroupId(groupId);
+
+            if(belongs.size() == 1 && belongs.get(0).isLeader() && belongs.get(0).getRunner() == runner.get()) {
+                belongRepository.deleteByRunnerIdAndGroupId(runnerId, groupId);
+                groupRepository.delete(group);
+            }
+        }
     }
 }

--- a/src/main/java/park/brothers/runwith_back/domain/Runner/controller/RunnerController.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Runner/controller/RunnerController.java
@@ -3,18 +3,12 @@ package park.brothers.runwith_back.domain.Runner.controller;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
-import org.springframework.validation.FieldError;
 import org.springframework.web.bind.annotation.*;
 import park.brothers.runwith_back.common.Response.ValidationErrorUtils;
-import park.brothers.runwith_back.domain.Runner.dto.CreateRunnerDto;
-import park.brothers.runwith_back.domain.Runner.repository.MemoryRunnerRepository;
+import park.brothers.runwith_back.domain.Runner.dto.Request.CreateRunnerRequestDto;
 import park.brothers.runwith_back.domain.Runner.service.RunnerService;
-
-import java.util.HashMap;
-import java.util.Map;
 
 @Slf4j
 @RestController
@@ -24,13 +18,13 @@ public class RunnerController {
     private final RunnerService runnerService;
 
     @PostMapping("/add")
-    public ResponseEntity<Object> save(@RequestBody @Valid CreateRunnerDto createRunnerDto, BindingResult bindingResult) {
+    public ResponseEntity<Object> save(@RequestBody @Valid CreateRunnerRequestDto createRunnerRequestDto, BindingResult bindingResult) {
         if (bindingResult.hasErrors()) {
             return ValidationErrorUtils.handleValidationErrors(bindingResult);
         }
 
-        runnerService.save(createRunnerDto);
+        runnerService.save(createRunnerRequestDto);
 
-        return ResponseEntity.ok(createRunnerDto);
+        return ResponseEntity.ok(createRunnerRequestDto);
     }
 }

--- a/src/main/java/park/brothers/runwith_back/domain/Runner/dto/Request/CreateRunnerRequestDto.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Runner/dto/Request/CreateRunnerRequestDto.java
@@ -1,4 +1,4 @@
-package park.brothers.runwith_back.domain.Runner.dto;
+package park.brothers.runwith_back.domain.Runner.dto.Request;
 
 import jakarta.validation.constraints.NotEmpty;
 import lombok.Data;
@@ -6,7 +6,7 @@ import lombok.Getter;
 
 @Data
 @Getter
-public class CreateRunnerDto {
+public class CreateRunnerRequestDto {
     @NotEmpty
     private String name;
 

--- a/src/main/java/park/brothers/runwith_back/domain/Runner/dto/Response/GetRunnerResponseDto.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Runner/dto/Response/GetRunnerResponseDto.java
@@ -1,0 +1,16 @@
+package park.brothers.runwith_back.domain.Runner.dto.Response;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class GetRunnerResponseDto {
+
+    @NotEmpty
+    Long id;
+
+    @NotEmpty
+    String name;
+}

--- a/src/main/java/park/brothers/runwith_back/domain/Runner/repository/JPARunnerRepository.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Runner/repository/JPARunnerRepository.java
@@ -1,6 +1,7 @@
 package park.brothers.runwith_back.domain.Runner.repository;
 
 import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Repository;
@@ -13,13 +14,10 @@ import java.util.*;
 @Slf4j
 @Primary
 @Transactional
+@RequiredArgsConstructor
 public class JPARunnerRepository implements RunnerRepository {
 
     private final EntityManager em;
-
-    public JPARunnerRepository(EntityManager em) {
-        this.em = em;
-    }
 
     @Override
     @Transactional
@@ -34,5 +32,12 @@ public class JPARunnerRepository implements RunnerRepository {
                 .getResultList();
 
         return result.stream().findFirst();
+    }
+
+    @Override
+    public Optional<Runner> findById(Long runnerId) {
+        return Optional.ofNullable(em.createQuery("select r from Runner r where r.id = :id", Runner.class)
+                .setParameter("id", runnerId)
+                .getSingleResult());
     }
 }

--- a/src/main/java/park/brothers/runwith_back/domain/Runner/repository/MemoryRunnerRepository.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Runner/repository/MemoryRunnerRepository.java
@@ -17,8 +17,8 @@ public class MemoryRunnerRepository implements RunnerRepository {
         store.put(runner.getId(), runner);
     }
 
-    public Runner findById(Long id){
-        return store.get(id);
+    public Optional<Runner> findById(Long id){
+        return Optional.ofNullable(store.get(id));
     }
 
     public Optional<Runner> findByEmail(String email){

--- a/src/main/java/park/brothers/runwith_back/domain/Runner/repository/RunnerRepository.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Runner/repository/RunnerRepository.java
@@ -8,4 +8,6 @@ public interface RunnerRepository {
     void save(Runner runner);
 
     Optional<Runner> findByEmail(String email);
+
+    Optional<Runner> findById(Long runnerId);
 }

--- a/src/main/java/park/brothers/runwith_back/domain/Runner/service/RunnerService.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Runner/service/RunnerService.java
@@ -1,7 +1,7 @@
 package park.brothers.runwith_back.domain.Runner.service;
 
-import park.brothers.runwith_back.domain.Runner.dto.CreateRunnerDto;
+import park.brothers.runwith_back.domain.Runner.dto.Request.CreateRunnerRequestDto;
 
 public interface RunnerService {
-    void save(CreateRunnerDto createRunnerDto);
+    void save(CreateRunnerRequestDto createRunnerRequestDto);
 }

--- a/src/main/java/park/brothers/runwith_back/domain/Runner/service/Version1RunnerService.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Runner/service/Version1RunnerService.java
@@ -2,7 +2,7 @@ package park.brothers.runwith_back.domain.Runner.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import park.brothers.runwith_back.domain.Runner.dto.CreateRunnerDto;
+import park.brothers.runwith_back.domain.Runner.dto.Request.CreateRunnerRequestDto;
 import park.brothers.runwith_back.domain.Runner.entity.Runner;
 import park.brothers.runwith_back.domain.Runner.repository.RunnerRepository;
 
@@ -13,14 +13,14 @@ public class Version1RunnerService implements RunnerService {
     private final RunnerRepository runnerRepository;
 
     @Override
-    public void save(CreateRunnerDto createRunnerDto) {
+    public void save(CreateRunnerRequestDto createRunnerRequestDto) {
         Runner runner = new Runner();
-        runner.setName(createRunnerDto.getName());
-        runner.setPassword(createRunnerDto.getPassword());
-        runner.setEmail(createRunnerDto.getEmail());
+        runner.setName(createRunnerRequestDto.getName());
+        runner.setPassword(createRunnerRequestDto.getPassword());
+        runner.setEmail(createRunnerRequestDto.getEmail());
 
-        if(createRunnerDto.getImageLink() != null){
-            runner.setImageLink(createRunnerDto.getImageLink());
+        if(createRunnerRequestDto.getImageLink() != null){
+            runner.setImageLink(createRunnerRequestDto.getImageLink());
         }
 
         runnerRepository.save(runner);


### PR DESCRIPTION
## #️⃣연관된 이슈

> ##7 Belong 기능 구현

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- Belong Domain
1. Belong 저장 기능 (그룹에 참여하기)
2. Belong 삭제 기능(그룹 탈퇴하기)
3. 자신이 속한 모든 그룹 조회하기
4. 특정 그룹에 속한 모든 runner 조회하기
5. 그룹 내 리더 바꾸기

- Group Domain
1. 그룹 생성 시, 해당 그룹으로 생성 러너가 Belong되도록 하며, 리더로 참여하게 되도록 수정
2. 그룹 삭제 시, 해당 그룹에 더 속한 러너들이 없는지, 삭제하려는 사람이 리더인지, 삭제하려는 사람이 리더와 동일 인물인지 확인

- Others
1. 모든 도메인 패키지들의 Dto 패키지 구조를 Request와 Response로 분리

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?