### PR TITLE
[fix] 로그인 시, 로그인 id와 러너 이름을 모두 받도록 수정

### DIFF
--- a/src/main/java/park/brothers/runwith_back/domain/Login/controller/LoginController.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Login/controller/LoginController.java
@@ -35,20 +35,15 @@ public class LoginController {
         }
 
         //로그인
-        String loginRunnerId = loginService.login(loginRequestDto);
-        log.info("loginRunnerId = {}", loginRunnerId);
-        //로그인 성공 여부 파악
-        if(loginRunnerId.isEmpty()){
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new CommonMessage("아이디 또는 비밀번호가 일치하지 않습니다."));
-        }
+        LoginResponseDto loginResponseDto = loginService.login(loginRequestDto);
 
         //Http 쿠키 설정
-        Cookie idCookie = new Cookie("runnerId", loginRunnerId);
+        Cookie idCookie = new Cookie("runnerId", loginResponseDto.getRunnerId());
         idCookie.setPath("/");
         idCookie.setHttpOnly(true);
         response.addCookie(idCookie);
 
-        return ResponseEntity.status(HttpStatus.OK).body(new LoginResponseDto(loginRunnerId));
+        return ResponseEntity.status(HttpStatus.OK).body(loginResponseDto);
     }
 
 

--- a/src/main/java/park/brothers/runwith_back/domain/Login/dto/Response/LoginResponseDto.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Login/dto/Response/LoginResponseDto.java
@@ -10,4 +10,7 @@ public class LoginResponseDto {
 
     @NotEmpty
     private String runnerId; //러너ID
+
+    @NotEmpty
+    private String runnerName; //러너 이름
 }

--- a/src/main/java/park/brothers/runwith_back/domain/Login/service/LoginService.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Login/service/LoginService.java
@@ -1,7 +1,8 @@
 package park.brothers.runwith_back.domain.Login.service;
 
 import park.brothers.runwith_back.domain.Login.dto.Request.LoginRequestDto;
+import park.brothers.runwith_back.domain.Login.dto.Response.LoginResponseDto;
 
 public interface LoginService {
-    String login(LoginRequestDto loginRequestDto);
+    LoginResponseDto login(LoginRequestDto loginRequestDto);
 }

--- a/src/main/java/park/brothers/runwith_back/domain/Login/service/Version1LoginService.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Login/service/Version1LoginService.java
@@ -2,7 +2,9 @@ package park.brothers.runwith_back.domain.Login.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import park.brothers.runwith_back.common.Exceptions.ResourceNotFoundException;
 import park.brothers.runwith_back.domain.Login.dto.Request.LoginRequestDto;
+import park.brothers.runwith_back.domain.Login.dto.Response.LoginResponseDto;
 import park.brothers.runwith_back.domain.Runner.entity.Runner;
 import park.brothers.runwith_back.domain.Runner.repository.RunnerRepository;
 
@@ -14,18 +16,18 @@ public class Version1LoginService implements LoginService {
 
     private final RunnerRepository runnerRepository;
 
-    public String login(LoginRequestDto loginRequestDto) {
+    public LoginResponseDto login(LoginRequestDto loginRequestDto) {
         Optional<Runner> runner = runnerRepository.findByEmail(loginRequestDto.getLoginEmail())
                 .filter(r -> r.getPassword().equals(loginRequestDto.getLoginPassword()));
 
         //runner가 있으면 로그인 성공
-        if(runner.isPresent()){
-            return runner.get().getId().toString();
+        if(runner.isEmpty()){
+            throw new ResourceNotFoundException("이메일 또는 비밀번호가 다릅니다.");
         }
-        //없으면 실패
-        else {
-            return "";
-        }
+        return new LoginResponseDto(
+                runner.get().getId().toString(),
+                runner.get().getName()
+        );
     }
 
 }

--- a/src/test/java/park/brothers/runwith_back/domain/Login/controller/LoginControllerTest.java
+++ b/src/test/java/park/brothers/runwith_back/domain/Login/controller/LoginControllerTest.java
@@ -12,8 +12,11 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import park.brothers.runwith_back.domain.Login.dto.Request.LoginRequestDto;
+import park.brothers.runwith_back.domain.Login.dto.Response.LoginResponseDto;
 import park.brothers.runwith_back.domain.Login.service.LoginService;
 import tools.jackson.databind.ObjectMapper;
+
+import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -48,8 +51,13 @@ class LoginControllerTest {
                 "test_email",
                 "test_password"
         );
+        UUID runnerUUID = UUID.randomUUID();
+        LoginResponseDto loginResponseDto = new LoginResponseDto(
+                runnerUUID.toString(),
+                "test_runner"
+        );
         //servive 가정 선언
-        given(loginService.login(any(LoginRequestDto.class))).willReturn("1");
+        given(loginService.login(any(LoginRequestDto.class))).willReturn(loginResponseDto);
 
         //when & then
         String content = new ObjectMapper().writeValueAsString(loginRequestDto);
@@ -58,31 +66,9 @@ class LoginControllerTest {
                         .contentType(MediaType.APPLICATION_JSON) // 요청 타입 확인
                         .content(content)) // Body에 JSON 문자열 담기
                 .andExpect(status().isOk()) //
-                .andExpect(jsonPath("$.runnerId").value("1")) // runnerId 확인
-                .andExpect(cookie().value("runnerId", "1")); //쿠키값 테스트
-
-    }
-
-    @Test
-    @DisplayName("로그인 실패 컨트롤러 테스트")
-    void loginFail() throws Exception {
-        //given
-        //로그인 requestdto 생성
-        LoginRequestDto loginRequestDto = new LoginRequestDto(
-                "test_email",
-                "test_password"
-        );
-        //servive 가정 선언
-        given(loginService.login(any(LoginRequestDto.class))).willReturn("");
-
-        //when & then
-        String content = new ObjectMapper().writeValueAsString(loginRequestDto);
-
-        mockMvc.perform(post("/api/v1/runners/login") // POST 요청 URL
-                        .contentType(MediaType.APPLICATION_JSON) // 요청 타입 확인
-                        .content(content)) // Body에 JSON 문자열 담기
-                .andExpect(status().isUnauthorized()) //
-                .andExpect(jsonPath("$.message").value("아이디 또는 비밀번호가 일치하지 않습니다.")); // runnerId 확인
+                .andExpect(jsonPath("$.runnerId").value(runnerUUID.toString())) // runnerId 확인
+                .andExpect(cookie().value("runnerId", runnerUUID.toString())) //쿠키값 테스트
+                .andExpect(jsonPath("$.runnerName").value("test_runner"));
 
     }
 

--- a/src/test/java/park/brothers/runwith_back/domain/Login/service/Version1LoginServiceTest.java
+++ b/src/test/java/park/brothers/runwith_back/domain/Login/service/Version1LoginServiceTest.java
@@ -6,13 +6,16 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import park.brothers.runwith_back.common.Exceptions.ResourceNotFoundException;
 import park.brothers.runwith_back.domain.Login.dto.Request.LoginRequestDto;
+import park.brothers.runwith_back.domain.Login.dto.Response.LoginResponseDto;
 import park.brothers.runwith_back.domain.Runner.entity.Runner;
 import park.brothers.runwith_back.domain.Runner.repository.RunnerRepository;
 
 import java.util.Optional;
 import java.util.UUID;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 
@@ -45,11 +48,16 @@ class Version1LoginServiceTest {
         runner.setPassword("test_password");
         runner.setName("test_name");
 
+        LoginResponseDto loginResponseDto =  new LoginResponseDto(
+                fakeRunnerUUID.toString(),
+                "test_name"
+        );
+
         //이메일로 찾을 시, 잘 찾아지는지 확인
         given(runnerRepository.findByEmail(anyString())).willReturn(Optional.of(runner));
 
         //then
-        assertThat(loginService.login(loginRequestDto)).isEqualTo(fakeRunnerUUID.toString()); //Id가 잘 반환되는지 확인
+        assertThat(loginService.login(loginRequestDto)).isEqualTo(loginResponseDto); //response가 잘 반환되는지 확인
     }
 
     @Test
@@ -66,6 +74,6 @@ class Version1LoginServiceTest {
         given(runnerRepository.findByEmail(anyString())).willReturn(Optional.empty());
 
         //then
-        assertThat(loginService.login(loginRequestDto)).isEmpty(); //null값이 반환되는지 확인
+        assertThrows(ResourceNotFoundException.class, () -> loginService.login(loginRequestDto)); //null값이 반환되는지 확인
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

로그인 시 runnerName을 같이 반환하도록 수정

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
로그인 시 runnerName을 같이 반환하도록 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?