### PR TITLE
[fix] 로그인 시, 로그인 id와 러너 이름, 이미지 링크까지 받도록 수정

### DIFF
--- a/src/main/java/park/brothers/runwith_back/domain/Login/dto/Response/LoginResponseDto.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Login/dto/Response/LoginResponseDto.java
@@ -13,4 +13,6 @@ public class LoginResponseDto {
 
     @NotEmpty
     private String runnerName; //러너 이름
+
+    private String runnerImageLink; //러너 이미지 링크
 }

--- a/src/main/java/park/brothers/runwith_back/domain/Login/service/Version1LoginService.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Login/service/Version1LoginService.java
@@ -7,6 +7,7 @@ import park.brothers.runwith_back.domain.Login.dto.Request.LoginRequestDto;
 import park.brothers.runwith_back.domain.Login.dto.Response.LoginResponseDto;
 import park.brothers.runwith_back.domain.Runner.entity.Runner;
 import park.brothers.runwith_back.domain.Runner.repository.RunnerRepository;
+import park.brothers.runwith_back.external.AWS_S3.AWSS3Service;
 
 import java.util.Optional;
 
@@ -15,6 +16,8 @@ import java.util.Optional;
 public class Version1LoginService implements LoginService {
 
     private final RunnerRepository runnerRepository;
+
+    private final AWSS3Service awss3Service;
 
     public LoginResponseDto login(LoginRequestDto loginRequestDto) {
         Optional<Runner> runner = runnerRepository.findByEmail(loginRequestDto.getLoginEmail())
@@ -26,7 +29,8 @@ public class Version1LoginService implements LoginService {
         }
         return new LoginResponseDto(
                 runner.get().getId().toString(),
-                runner.get().getName()
+                runner.get().getName(),
+                awss3Service.getImagePresignedUrl("runners", runner.get().getId().toString(), 0)
         );
     }
 

--- a/src/test/java/park/brothers/runwith_back/domain/Login/controller/LoginControllerTest.java
+++ b/src/test/java/park/brothers/runwith_back/domain/Login/controller/LoginControllerTest.java
@@ -54,7 +54,8 @@ class LoginControllerTest {
         UUID runnerUUID = UUID.randomUUID();
         LoginResponseDto loginResponseDto = new LoginResponseDto(
                 runnerUUID.toString(),
-                "test_runner"
+                "test_runner",
+                "test_imageLink"
         );
         //servive 가정 선언
         given(loginService.login(any(LoginRequestDto.class))).willReturn(loginResponseDto);

--- a/src/test/java/park/brothers/runwith_back/domain/Login/service/Version1LoginServiceTest.java
+++ b/src/test/java/park/brothers/runwith_back/domain/Login/service/Version1LoginServiceTest.java
@@ -11,11 +11,13 @@ import park.brothers.runwith_back.domain.Login.dto.Request.LoginRequestDto;
 import park.brothers.runwith_back.domain.Login.dto.Response.LoginResponseDto;
 import park.brothers.runwith_back.domain.Runner.entity.Runner;
 import park.brothers.runwith_back.domain.Runner.repository.RunnerRepository;
+import park.brothers.runwith_back.external.AWS_S3.AWSS3Service;
 
 import java.util.Optional;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 
@@ -26,6 +28,9 @@ class Version1LoginServiceTest {
 
     @Mock
     private RunnerRepository runnerRepository;
+
+    @Mock
+    private AWSS3Service awss3Service;
 
     @InjectMocks
     private Version1LoginService loginService;
@@ -50,11 +55,13 @@ class Version1LoginServiceTest {
 
         LoginResponseDto loginResponseDto =  new LoginResponseDto(
                 fakeRunnerUUID.toString(),
-                "test_name"
+                "test_name",
+                "test_imageLink"
         );
 
         //이메일로 찾을 시, 잘 찾아지는지 확인
         given(runnerRepository.findByEmail(anyString())).willReturn(Optional.of(runner));
+        given(awss3Service.getImagePresignedUrl(anyString(), anyString(), anyInt())).willReturn("test_imageLink");
 
         //then
         assertThat(loginService.login(loginRequestDto)).isEqualTo(loginResponseDto); //response가 잘 반환되는지 확인


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#39 
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- response dto 수정
- 서비스에서 AWSS3Service에 접근하여 이미지 링크 받아오기 추가
- 컨트롤러 및 서비스 테스트 코드 수정