### PR TITLE
[feat] 그룹 신청 도메인인 JoinRequest 패키지 구현

### DIFF
--- a/src/main/java/park/brothers/runwith_back/domain/JoinRequest/controller/JoinRequestController.java
+++ b/src/main/java/park/brothers/runwith_back/domain/JoinRequest/controller/JoinRequestController.java
@@ -1,0 +1,115 @@
+package park.brothers.runwith_back.domain.JoinRequest.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.*;
+import park.brothers.runwith_back.common.CommonMessage;
+import park.brothers.runwith_back.common.Response.ValidationErrorUtils;
+import park.brothers.runwith_back.domain.JoinRequest.dto.request.CreateJoinRequestRequestDto;
+import park.brothers.runwith_back.domain.JoinRequest.dto.response.CreateJoinRequestResponseDto;
+import park.brothers.runwith_back.domain.JoinRequest.dto.response.GetJoinRequestResponseDto;
+import park.brothers.runwith_back.domain.JoinRequest.dto.response.GetMyJoinRequestsResponseDto;
+import park.brothers.runwith_back.domain.JoinRequest.service.JoinRequestService;
+
+import java.io.IOException;
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/join-requests")
+public class JoinRequestController {
+
+    private final JoinRequestService joinRequestService;
+
+    //그룹 가입 신청 생성 api
+    @PostMapping
+    @Operation(summary = "그룹 가입 신청 생성",description = "그룹에 가입 신청합니다.")
+    public ResponseEntity<Object> save(
+            @AuthenticationPrincipal String runnerId,
+            @Parameter(
+                    description = "그룹 가입 신청 정보",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE)
+            )
+            @RequestBody @Valid CreateJoinRequestRequestDto createJoinRequestRequestDto,
+            BindingResult bindingResult
+    ) throws IOException { //BindingResult은 DTO만
+        if (bindingResult.hasErrors()) {
+            return ValidationErrorUtils.handleValidationErrors(bindingResult);
+        }
+
+        CreateJoinRequestResponseDto createJoinRequestResponseDto = joinRequestService.save(runnerId, createJoinRequestRequestDto);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(createJoinRequestResponseDto);
+    }
+
+    //그룹 가입 신청 삭제 api
+    @DeleteMapping("/{joinRequestId}")
+    @Operation(summary = "그룹 가입 신청 삭제",description = "신청한 그룹 가입을 삭제합니다.")
+    public ResponseEntity<Object> deleteJoinRequest(
+            @AuthenticationPrincipal String runnerId,
+            @PathVariable @Valid String joinRequestId
+    ){
+        joinRequestService.delete(runnerId, joinRequestId);
+
+        return ResponseEntity.status(HttpStatus.OK).body(new CommonMessage("신청한 그룹 가입이 삭제되었습니다."));
+    }
+
+    //그룹 가입 신청 승인 api(리더)
+    @PostMapping("/accept/{joinRequestId}")
+    @Operation(summary = "그룹 신청 승인", description = "리더가 그룹 가입 신청 하나를 승인합니다.")
+    public ResponseEntity<Object> acceptJoinRequest(
+            @AuthenticationPrincipal String runnerId,
+            @PathVariable @Valid String joinRequestId
+    ){
+        joinRequestService.accept(runnerId, joinRequestId);
+
+        return ResponseEntity.status(HttpStatus.OK).body(new CommonMessage("성공적으로 승인되었습니다."));
+    }
+
+    //그룹 가입 신청 거부 api(리더)
+    @PostMapping("/reject/{joinRequestId}")
+    @Operation(summary = "그룹 신청 거절", description = "리더가 그룹 가입 신청 하나를 거절합니다.")
+    public ResponseEntity<Object> rejectJoinRequest(
+            @AuthenticationPrincipal String runnerId,
+            @PathVariable @Valid String joinRequestId
+    ){
+        joinRequestService.reject(runnerId, joinRequestId);
+
+        return ResponseEntity.status(HttpStatus.OK).body(new CommonMessage("성공적으로 거절되었습니다."));
+    }
+
+    //그룹 가입 신청 명단 보기(리더)
+    @GetMapping("/{groupId}")
+    @Operation(summary = "그룹 신청 명단 보기", description = "리더가 그룹 신청 명단을 조회합니다.")
+    public ResponseEntity<Object> getJoinRequestList(
+            @AuthenticationPrincipal String runnerId,
+            @PathVariable @Valid String groupId
+    ){
+        List<GetJoinRequestResponseDto> getJoinRequestResponseDtos = joinRequestService.getJoinRequestOfGroup(runnerId, groupId);
+
+        return ResponseEntity.status(HttpStatus.OK).body(getJoinRequestResponseDtos);
+    }
+
+    //내 가입 신청 보기
+    @GetMapping("/mine")
+    @Operation(summary = "나의 신청 보기", description = "내가 신청한 그룹 신청 명단을 조회합니다.")
+    public  ResponseEntity<Object> getMyJoinRequest(
+            @AuthenticationPrincipal String runnerId
+    ){
+        List<GetMyJoinRequestsResponseDto> getMyJoinRequestsResponseDtos = joinRequestService.getMyJoinRequest(runnerId);
+
+        return ResponseEntity.status(HttpStatus.OK).body(getMyJoinRequestsResponseDtos);
+    }
+
+
+}

--- a/src/main/java/park/brothers/runwith_back/domain/JoinRequest/dto/request/CreateJoinRequestRequestDto.java
+++ b/src/main/java/park/brothers/runwith_back/domain/JoinRequest/dto/request/CreateJoinRequestRequestDto.java
@@ -1,0 +1,14 @@
+package park.brothers.runwith_back.domain.JoinRequest.dto.request;
+
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Data;
+import lombok.Getter;
+
+@Data
+@Getter
+public class CreateJoinRequestRequestDto {
+
+    @NotEmpty
+    private String groupId; //가입하고 싶은 그룹 id
+}

--- a/src/main/java/park/brothers/runwith_back/domain/JoinRequest/dto/response/CreateJoinRequestResponseDto.java
+++ b/src/main/java/park/brothers/runwith_back/domain/JoinRequest/dto/response/CreateJoinRequestResponseDto.java
@@ -1,0 +1,25 @@
+package park.brothers.runwith_back.domain.JoinRequest.dto.response;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Data
+@Setter
+@AllArgsConstructor
+public class CreateJoinRequestResponseDto {
+
+    @NotEmpty
+    private String joinRequestId; //가입 신청 uuid
+
+    @NotEmpty
+    private String groupId; //가입할 그룹 id
+
+    @NotEmpty
+    private String groupName; //가입할 그룹 이름
+
+    private LocalDateTime createdAt; //가입 신청한 시간
+}

--- a/src/main/java/park/brothers/runwith_back/domain/JoinRequest/dto/response/GetJoinRequestResponseDto.java
+++ b/src/main/java/park/brothers/runwith_back/domain/JoinRequest/dto/response/GetJoinRequestResponseDto.java
@@ -1,0 +1,22 @@
+package park.brothers.runwith_back.domain.JoinRequest.dto.response;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Data
+@Setter
+@AllArgsConstructor
+public class GetJoinRequestResponseDto {
+
+    @NotEmpty
+    private String joinRequestId;
+
+    @NotEmpty
+    private String runnerId;
+
+    private LocalDateTime createdAt; //가입 신청한 시간
+}

--- a/src/main/java/park/brothers/runwith_back/domain/JoinRequest/dto/response/GetMyJoinRequestsResponseDto.java
+++ b/src/main/java/park/brothers/runwith_back/domain/JoinRequest/dto/response/GetMyJoinRequestsResponseDto.java
@@ -1,0 +1,19 @@
+package park.brothers.runwith_back.domain.JoinRequest.dto.response;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+public class GetMyJoinRequestsResponseDto {
+    @NotEmpty
+    private String joinRequestId;
+
+    @NotEmpty
+    private String groupId;
+
+    private LocalDateTime createdAt; //가입 신청한 시간
+}

--- a/src/main/java/park/brothers/runwith_back/domain/JoinRequest/entity/JoinRequest.java
+++ b/src/main/java/park/brothers/runwith_back/domain/JoinRequest/entity/JoinRequest.java
@@ -1,0 +1,37 @@
+package park.brothers.runwith_back.domain.JoinRequest.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import park.brothers.runwith_back.domain.Group.entity.Group;
+import park.brothers.runwith_back.domain.Runner.entity.Runner;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "join_request")
+public class JoinRequest {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(updatable = false, nullable = false)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "runners")
+    private Runner runner;
+
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "groups")
+    private Group group;
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+}

--- a/src/main/java/park/brothers/runwith_back/domain/JoinRequest/repository/JPAJoinRequestRepository.java
+++ b/src/main/java/park/brothers/runwith_back/domain/JoinRequest/repository/JPAJoinRequestRepository.java
@@ -1,0 +1,72 @@
+package park.brothers.runwith_back.domain.JoinRequest.repository;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+import park.brothers.runwith_back.domain.JoinRequest.entity.JoinRequest;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+@Slf4j
+@Primary
+@Transactional
+@RequiredArgsConstructor
+public class JPAJoinRequestRepository implements JoinRequestRepository {
+
+    private final EntityManager em;
+
+
+    //id로 찾기
+    @Override
+    public Optional<JoinRequest> findById(UUID joinRequestUUID) {
+        return em.createQuery("select j from JoinRequest j where j.id = :id", JoinRequest.class)
+                .setParameter("id", joinRequestUUID)
+                .getResultStream()
+                .findFirst();
+    }
+
+    //runner와 group으로 찾기
+    @Override
+    public Optional<JoinRequest> findByRunnerIdAndGroupId(String runnerId, UUID groupId) {
+        return em.createQuery("select j from JoinRequest j where j.runner.id = :runnerId and j.group.id = :groupId", JoinRequest.class)
+                .setParameter("runnerId", runnerId)
+                .setParameter("groupId", groupId)
+                .getResultStream()
+                .findFirst();
+    }
+
+    //저장하기
+    @Override
+    public JoinRequest save(JoinRequest newJoinRequest) {
+        em.persist(newJoinRequest);
+        return newJoinRequest;
+    }
+
+    //삭제하기
+    @Override
+    public void delete(JoinRequest joinRequest) {
+        em.remove(joinRequest);
+    }
+
+    //그룹 id로 모두 찾기
+    @Override
+    public List<JoinRequest> findByGroupId(UUID groupUUID) {
+        return em.createQuery("select j from JoinRequest j where j.group.id = :groupId", JoinRequest.class)
+                .setParameter("groupId", groupUUID)
+                .getResultList();
+    }
+
+    //러너 id로 모두 찾기
+    @Override
+    public List<JoinRequest> findByRunnerId(String runnerId) {
+        return em.createQuery("select j from JoinRequest j where j.runner.id = :runnerId", JoinRequest.class)
+                .setParameter("runnerId", runnerId)
+                .getResultList();
+    }
+}

--- a/src/main/java/park/brothers/runwith_back/domain/JoinRequest/repository/JoinRequestRepository.java
+++ b/src/main/java/park/brothers/runwith_back/domain/JoinRequest/repository/JoinRequestRepository.java
@@ -1,0 +1,22 @@
+package park.brothers.runwith_back.domain.JoinRequest.repository;
+
+import park.brothers.runwith_back.domain.JoinRequest.entity.JoinRequest;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface JoinRequestRepository {
+
+    Optional<JoinRequest> findById(UUID joinRequestUUID);
+
+    Optional<JoinRequest> findByRunnerIdAndGroupId(String runnerId, UUID groupId);
+
+    JoinRequest save(JoinRequest newJoinRequest);
+
+    void delete(JoinRequest joinRequest);
+
+    List<JoinRequest> findByGroupId(UUID groupUUID);
+
+    List<JoinRequest> findByRunnerId(String runnerId);
+}

--- a/src/main/java/park/brothers/runwith_back/domain/JoinRequest/service/JoinRequestService.java
+++ b/src/main/java/park/brothers/runwith_back/domain/JoinRequest/service/JoinRequestService.java
@@ -1,0 +1,24 @@
+package park.brothers.runwith_back.domain.JoinRequest.service;
+
+import jakarta.validation.Valid;
+import park.brothers.runwith_back.domain.JoinRequest.dto.request.CreateJoinRequestRequestDto;
+import park.brothers.runwith_back.domain.JoinRequest.dto.response.CreateJoinRequestResponseDto;
+import park.brothers.runwith_back.domain.JoinRequest.dto.response.GetJoinRequestResponseDto;
+import park.brothers.runwith_back.domain.JoinRequest.dto.response.GetMyJoinRequestsResponseDto;
+
+import java.util.List;
+
+public interface JoinRequestService {
+
+    CreateJoinRequestResponseDto save(String runnerId, @Valid CreateJoinRequestRequestDto createJoinRequestRequestDto);
+
+    void delete(String runnerId, @Valid String joinRequestId);
+
+    void accept(String runnerId, @Valid String joinRequestId);
+
+    void reject(String runnerId, @Valid String joinRequestId);
+
+    List<GetJoinRequestResponseDto> getJoinRequestOfGroup(String runnerId, @Valid String groupId);
+
+    List<GetMyJoinRequestsResponseDto> getMyJoinRequest(String runnerId);
+}

--- a/src/main/java/park/brothers/runwith_back/domain/JoinRequest/service/Version1JoinRequestService.java
+++ b/src/main/java/park/brothers/runwith_back/domain/JoinRequest/service/Version1JoinRequestService.java
@@ -1,0 +1,223 @@
+package park.brothers.runwith_back.domain.JoinRequest.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import park.brothers.runwith_back.common.Exceptions.NotAcceptableException;
+import park.brothers.runwith_back.common.Exceptions.ResourceNotFoundException;
+import park.brothers.runwith_back.common.Exceptions.UnauthorizedException;
+import park.brothers.runwith_back.domain.Belong.entity.Belong;
+import park.brothers.runwith_back.domain.Belong.repository.BelongRepository;
+import park.brothers.runwith_back.domain.Group.entity.Group;
+import park.brothers.runwith_back.domain.Group.repository.GroupRepository;
+import park.brothers.runwith_back.domain.JoinRequest.dto.request.CreateJoinRequestRequestDto;
+import park.brothers.runwith_back.domain.JoinRequest.dto.response.CreateJoinRequestResponseDto;
+import park.brothers.runwith_back.domain.JoinRequest.dto.response.GetJoinRequestResponseDto;
+import park.brothers.runwith_back.domain.JoinRequest.dto.response.GetMyJoinRequestsResponseDto;
+import park.brothers.runwith_back.domain.JoinRequest.entity.JoinRequest;
+import park.brothers.runwith_back.domain.JoinRequest.repository.JoinRequestRepository;
+import park.brothers.runwith_back.domain.Runner.entity.Runner;
+import park.brothers.runwith_back.domain.Runner.repository.RunnerRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class Version1JoinRequestService implements JoinRequestService {
+
+    private final BelongRepository belongRepository;
+    private final JoinRequestRepository joinRequestRepository;
+    private final RunnerRepository runnerRepository;
+    private final GroupRepository groupRepository;
+
+    //그룹 가입 신청 생성하기
+    @Override
+    public CreateJoinRequestResponseDto save(String runnerId, CreateJoinRequestRequestDto createJoinRequestRequestDto) {
+        //러너가 존재하지 않으면 안됨
+        Optional<Runner> runner = runnerRepository.findById(runnerId);
+        if(runner.isEmpty()){
+            throw new ResourceNotFoundException("존재하지 않는 러너입니다.");
+        }
+
+        //그룹이 존재하지 않으면 안됨
+        String groupStrId = createJoinRequestRequestDto.getGroupId();
+        UUID groupId = UUID.fromString(groupStrId);
+        Optional<Group> group = groupRepository.findById(groupId);
+        if(group.isEmpty()){
+            throw new ResourceNotFoundException("존재하지 않는 그룹입니다.");
+        }
+
+        //이미 가입되어 있으면 안됨
+        Optional<Belong> belong = belongRepository.findByRunnerIdAndGroupId(runnerId, groupId);
+        if(belong.isPresent()){
+            throw new NotAcceptableException("이미 가입된 그룹입니다.");
+        }
+
+        //이미 신청한 그룹이면 더이상 신청 안됨
+        Optional<JoinRequest> joinRequest = joinRequestRepository.findByRunnerIdAndGroupId(runnerId, groupId);
+        if(joinRequest.isPresent()){
+            throw new NotAcceptableException("이미 신청한 그룹입니다.");
+        }
+
+        //신청하기
+        JoinRequest newJoinRequest = new JoinRequest();
+        newJoinRequest.setRunner(runner.get());
+        newJoinRequest.setGroup(group.get());
+
+        JoinRequest savedJoinRequest = joinRequestRepository.save(newJoinRequest);
+
+        return new CreateJoinRequestResponseDto(
+                savedJoinRequest.getId().toString(),
+                savedJoinRequest.getGroup().getId().toString(),
+                savedJoinRequest.getGroup().getName(),
+                savedJoinRequest.getCreatedAt()
+        );
+    }
+
+    //그룹 가입 신청 철회
+    @Override
+    public void delete(String runnerId, String joinRequestId) {
+        UUID joinRequestUUID = UUID.fromString(joinRequestId);
+        Optional<JoinRequest> joinRequest = joinRequestRepository.findById(joinRequestUUID);
+
+        //신청이 존재하지 않으면 오류
+        if(joinRequest.isEmpty()){
+            throw new ResourceNotFoundException("존재하지 않는 그룹 가입 신청입니다.");
+        }
+
+        //러너가 존재하지 않으면 오류
+        Optional<Runner> runner = runnerRepository.findById(runnerId);
+        if(runner.isEmpty()){
+            throw new ResourceNotFoundException("존재하지 않는 러너입니다.");
+        }
+
+        //해당 러너가 이 가입 신청의 주인이 아니면 오류
+        if(!joinRequest.get().getRunner().getId().equals(runnerId)){
+            throw new UnauthorizedException("신청한 러너만이 가입 신청을 철회할 수 있습니다.");
+        }
+
+        joinRequestRepository.delete(joinRequest.get());
+    }
+
+    //그룹 가입 신청 승인
+    @Override
+    public void accept(String runnerId, String joinRequestId) {
+        UUID joinRequestUUID = UUID.fromString(joinRequestId);
+        Optional<JoinRequest> joinRequest = joinRequestRepository.findById(joinRequestUUID);
+
+        //신청이 존재하지 않으면 오류
+        if(joinRequest.isEmpty()){
+            throw new ResourceNotFoundException("존재하지 않는 그룹 가입 신청입니다.");
+        }
+
+        //러너가 존재하지 않으면 오류
+        Optional<Runner> runner = runnerRepository.findById(runnerId);
+        if(runner.isEmpty()){
+            throw new ResourceNotFoundException("존재하지 않는 러너입니다.");
+        }
+
+        //신청 관리 러너가 그룹에 속하는지 확인
+        Optional<Belong> belong = belongRepository.findByRunnerIdAndGroupId(runnerId, joinRequest.get().getGroup().getId());
+        if(belong.isEmpty()){
+            throw new ResourceNotFoundException("이 러너는 그룹에 속하지 않습니다.");
+        }
+
+        //리더인지 확인
+        if(!belong.get().isLeader()){
+            throw new UnauthorizedException("리더만이 신청 관리를 할 수 있습니다.");
+        }
+
+        Belong newBelong = new Belong();
+        newBelong.setRunner(joinRequest.get().getRunner());
+        newBelong.setGroup(joinRequest.get().getGroup());
+        newBelong.setLeader(false);
+        newBelong.setNickname(UUID.randomUUID().toString());
+
+        belongRepository.save(newBelong);
+        joinRequestRepository.delete(joinRequest.get());
+    }
+
+    // 그룹 가입 신청 거부
+    @Override
+    public void reject(String runnerId, String joinRequestId) {
+        UUID joinRequestUUID = UUID.fromString(joinRequestId);
+        Optional<JoinRequest> joinRequest = joinRequestRepository.findById(joinRequestUUID);
+
+        //신청이 존재하지 않으면 오류
+        if(joinRequest.isEmpty()){
+            throw new ResourceNotFoundException("존재하지 않는 그룹 가입 신청입니다.");
+        }
+
+        //러너가 존재하지 않으면 오류
+        Optional<Runner> runner = runnerRepository.findById(runnerId);
+        if(runner.isEmpty()){
+            throw new ResourceNotFoundException("존재하지 않는 러너입니다.");
+        }
+
+        //신청 관리 러너가 그룹에 속하는지 확인
+        Optional<Belong> belong = belongRepository.findByRunnerIdAndGroupId(runnerId, joinRequest.get().getGroup().getId());
+        if(belong.isEmpty()){
+            throw new ResourceNotFoundException("이 러너는 그룹에 속하지 않습니다.");
+        }
+
+        //리더인지 확인
+        if(!belong.get().isLeader()){
+            throw new UnauthorizedException("리더만이 신청 관리를 할 수 있습니다.");
+        }
+
+        joinRequestRepository.delete(joinRequest.get());
+    }
+
+    //리더가 그룹 신청 조회를 하는 기능
+    @Override
+    public List<GetJoinRequestResponseDto> getJoinRequestOfGroup(String runnerId, String groupId) {
+        //러너 존재 확인
+        Optional<Runner> runner = runnerRepository.findById(runnerId);
+        if(runner.isEmpty()){
+            throw new ResourceNotFoundException("존재하지 않는 러너입니다.");
+        }
+
+        //그룹 존재 확인
+        UUID groupUUID = UUID.fromString(groupId);
+        Optional<Group> group = groupRepository.findById(groupUUID);
+        if(group.isEmpty()){
+            throw new ResourceNotFoundException("존재하지 않는 그룹입니다.");
+        }
+
+        //신청 관리 러너가 그룹에 속하는지 확인
+        Optional<Belong> belong = belongRepository.findByRunnerIdAndGroupId(runnerId, groupUUID);
+        if(belong.isEmpty()){
+            throw new ResourceNotFoundException("이 러너는 그룹에 속하지 않습니다.");
+        }
+
+        //리더인지 확인
+        if(!belong.get().isLeader()){
+            throw new UnauthorizedException("리더만이 신청 관리를 할 수 있습니다.");
+        }
+
+        List<JoinRequest> joinRequests = joinRequestRepository.findByGroupId(groupUUID);
+
+        return joinRequests.stream()
+                .map(joinRequest -> new GetJoinRequestResponseDto(joinRequest.getId().toString(), joinRequest.getRunner().getId(), joinRequest.getCreatedAt()))
+                .collect(Collectors.toList());
+    }
+
+
+    //내가 신청한 신청 리스트 조회하기
+    @Override
+    public List<GetMyJoinRequestsResponseDto> getMyJoinRequest(String runnerId) {
+        //러너 존재 확인
+        Optional<Runner> runner = runnerRepository.findById(runnerId);
+        if(runner.isEmpty()){
+            throw new ResourceNotFoundException("존재하지 않는 러너입니다.");
+        }
+
+        List<JoinRequest> joinRequests = joinRequestRepository.findByRunnerId(runnerId);
+
+        return joinRequests.stream()
+                .map(joinRequest -> new GetMyJoinRequestsResponseDto(joinRequest.getId().toString(), joinRequest.getGroup().getId().toString(), joinRequest.getCreatedAt()))
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#50 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 신청 엔티티, 컨트롤러, dto, service, repository 구현
- 그룹 신청하기
- 그룹 신청 삭제하기
- 그룹 신청 승인하기(리더)
- 그룹 신청 거절하기(리더)
- 그룹에 신청한 모든 신청 보기(리더)
- 자신이 가입 신청한 그룹 보기