### PR TITLE
Hotfix

### DIFF
--- a/src/main/java/park/brothers/runwith_back/domain/Action/repository/ActionRepository.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Action/repository/ActionRepository.java
@@ -18,4 +18,6 @@ public interface ActionRepository {
     Action reviseAction(Action action, String name, String description, int startHour, int startMinute, int endHour, int endMinute, int maxImageSize);
 
     List<Action> findActionsByScheduleId(UUID scheduleId);
+
+    void deleteByScheduleId(UUID scheduleId);
 }

--- a/src/main/java/park/brothers/runwith_back/domain/Action/repository/JpaActionRepository.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Action/repository/JpaActionRepository.java
@@ -78,4 +78,12 @@ public class JpaActionRepository implements ActionRepository{
                 .setParameter("scheduleId", scheduleId)
                 .getResultList();
     }
+
+    //스케줄 id로 action 삭제
+    @Override
+    public void deleteByScheduleId(UUID scheduleId) {
+        em.createQuery("delete from Action a where a.schedule.id = :scheduleId")
+            .setParameter("scheduleId", scheduleId)
+            .executeUpdate();
+    }
 }

--- a/src/main/java/park/brothers/runwith_back/domain/Action/service/Version1ActionService.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Action/service/Version1ActionService.java
@@ -2,7 +2,6 @@ package park.brothers.runwith_back.domain.Action.service;
 
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/park/brothers/runwith_back/domain/Action/service/Version1ActionService.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Action/service/Version1ActionService.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import park.brothers.runwith_back.common.Exceptions.NotAcceptableException;
 import park.brothers.runwith_back.common.Exceptions.ResourceNotFoundException;
@@ -26,7 +27,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
-@Slf4j
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 @Primary
 public class Version1ActionService implements ActionService{
@@ -37,6 +38,7 @@ public class Version1ActionService implements ActionService{
 
     //action 생성하기
     @Override
+    @Transactional
     public CreateActionResponseDto createAction(String runnerId, CreateActionRequestDto createActionRequestDto, List<MultipartFile> images) throws IOException {
         //유효한 스케줄이어야 한다.
         String scheduleId = createActionRequestDto.getScheduleId();
@@ -115,6 +117,7 @@ public class Version1ActionService implements ActionService{
 
     //Action 삭제
     @Override
+    @Transactional
     public void deleteAction(String runnerId, String actionId) {
         Optional<Action> action = actionRepository.findById(UUID.fromString(actionId));
         //액션이 존재하지 않으면 에러
@@ -137,6 +140,7 @@ public class Version1ActionService implements ActionService{
 
     //Action 수정
     @Override
+    @Transactional
     public ReviseActionResponseDto reviseAction(String runnerId, String actionId, ReviseActionRequestDto reviseActionRequestDto, List<MultipartFile> images) throws IOException {
         Optional<Action> action = actionRepository.findById(UUID.fromString(actionId));
         //액션이 존재하지 않음

--- a/src/main/java/park/brothers/runwith_back/domain/Belong/repository/JPABelongRepository.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Belong/repository/JPABelongRepository.java
@@ -13,9 +13,8 @@ import java.util.Optional;
 import java.util.UUID;
 
 @Repository
-@Slf4j
 @Primary
-@Transactional
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class JPABelongRepository implements BelongRepository{
 
@@ -43,12 +42,14 @@ public class JPABelongRepository implements BelongRepository{
 
     //belong 저장
     @Override
+    @Transactional
     public Belong save(Belong belong) {
         em.persist(belong);
         return belong;
     }
 
     @Override
+    @Transactional
     public void deleteByRunnerIdAndGroupId(String runnerId, UUID groupId) {
         Optional<Belong> belong = Optional.ofNullable(em.createQuery("select b from Belong b where b.runner.id = :runnerId and b.group.id = :groupId", Belong.class)
                 .setParameter("runnerId", runnerId)
@@ -72,6 +73,7 @@ public class JPABelongRepository implements BelongRepository{
     }
 
     @Override
+    @Transactional
     public void changeIsLeader(String runnerId, UUID groupId, boolean isLeader) {
         Belong belong = em.createQuery("select b from Belong b where b.runner.id = :runnerId and b.group.id = :groupId", Belong.class)
                 .setParameter("runnerId", runnerId)

--- a/src/main/java/park/brothers/runwith_back/domain/Belong/repository/JPABelongRepository.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Belong/repository/JPABelongRepository.java
@@ -2,7 +2,6 @@ package park.brothers.runwith_back.domain.Belong.repository;
 
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/park/brothers/runwith_back/domain/Belong/service/Version1BelongService.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Belong/service/Version1BelongService.java
@@ -5,7 +5,6 @@ import org.springframework.stereotype.Service;
 import park.brothers.runwith_back.common.Exceptions.DuplicateResourceException;
 import park.brothers.runwith_back.common.Exceptions.ResourceNotFoundException;
 import park.brothers.runwith_back.common.Exceptions.UnauthorizedException;
-import park.brothers.runwith_back.domain.Action.entity.Action;
 import park.brothers.runwith_back.domain.Action.repository.ActionRepository;
 import park.brothers.runwith_back.domain.Belong.dto.Request.ChangeLeaderRequestDto;
 import park.brothers.runwith_back.domain.Belong.dto.Request.CreateBelongRequestDto;

--- a/src/main/java/park/brothers/runwith_back/domain/Belong/service/Version1BelongService.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Belong/service/Version1BelongService.java
@@ -16,6 +16,7 @@ import park.brothers.runwith_back.domain.Belong.entity.Belong;
 import park.brothers.runwith_back.domain.Belong.repository.BelongRepository;
 import park.brothers.runwith_back.domain.Group.entity.Group;
 import park.brothers.runwith_back.domain.Group.repository.GroupRepository;
+import park.brothers.runwith_back.domain.Recognize.repository.RecognizeRepository;
 import park.brothers.runwith_back.domain.Runner.entity.Runner;
 import park.brothers.runwith_back.domain.Runner.repository.RunnerRepository;
 import park.brothers.runwith_back.domain.Schedule.entity.Schedule;
@@ -36,6 +37,7 @@ public class Version1BelongService implements BelongService{
     private final GroupRepository groupRepository;
     private final ScheduleRepository scheduleRepository;
     private final ActionRepository actionRepository;
+    private final RecognizeRepository recognizeRepository;
     private final AWSS3Service aWSS3Service;
 
     // 그룹 참여
@@ -95,12 +97,11 @@ public class Version1BelongService implements BelongService{
         //그룹에서 생성된 Schedule 추출
         List<Schedule> schedules = scheduleRepository.findByBelongId(foundBelong.get().getId());
 
-        //스케줄로부터 생성된 모든 Actions들 삭제
         for(Schedule schedule : schedules){
-            List<Action> actions = actionRepository.findActionsByScheduleId(schedule.getId());
-            for(Action action : actions){
-                actionRepository.delete(action);
-            }
+            //스케줄로부터 생성된 모든 Actions들 삭제
+            actionRepository.deleteByScheduleId(schedule.getId());
+            //recognize도 삭제
+            recognizeRepository.deleteByScheduleId(schedule.getId());
             //actions들 삭제 다 하면 schedule를 삭제
             scheduleRepository.delete(schedule);
         }

--- a/src/main/java/park/brothers/runwith_back/domain/Belong/service/Version1BelongService.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Belong/service/Version1BelongService.java
@@ -2,6 +2,7 @@ package park.brothers.runwith_back.domain.Belong.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import park.brothers.runwith_back.common.Exceptions.DuplicateResourceException;
 import park.brothers.runwith_back.common.Exceptions.ResourceNotFoundException;
 import park.brothers.runwith_back.common.Exceptions.UnauthorizedException;
@@ -29,6 +30,7 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class Version1BelongService implements BelongService{
 
     private final BelongRepository belongRepository;
@@ -41,6 +43,7 @@ public class Version1BelongService implements BelongService{
 
     // 그룹 참여
     @Override
+    @Transactional
     public CreateBelongResponseDto joinGroup(String runnerId, CreateBelongRequestDto createBelongRequestDto) {
         String groupId = createBelongRequestDto.getGroupId();
         String nickname = createBelongRequestDto.getBelongNickname();
@@ -81,6 +84,7 @@ public class Version1BelongService implements BelongService{
     
     //그룹 탈퇴 기능
     @Override
+    @Transactional
     public void leaveGroup(String runnerId, String groupId) {
         UUID groupUUID = UUID.fromString(groupId);
 
@@ -128,6 +132,7 @@ public class Version1BelongService implements BelongService{
 
     //특정 그룹의 리더 변경하기
     @Override
+    @Transactional
     public void changeLeader(String oldLeaderRunnerId, ChangeLeaderRequestDto changeLeaderRequestDto) {
         String newLeaderRunnerId = changeLeaderRequestDto.getNewLeaderRunnerId();
         String groupId = changeLeaderRequestDto.getGroupId();

--- a/src/main/java/park/brothers/runwith_back/domain/Belong/service/Version1BelongService.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Belong/service/Version1BelongService.java
@@ -5,6 +5,8 @@ import org.springframework.stereotype.Service;
 import park.brothers.runwith_back.common.Exceptions.DuplicateResourceException;
 import park.brothers.runwith_back.common.Exceptions.ResourceNotFoundException;
 import park.brothers.runwith_back.common.Exceptions.UnauthorizedException;
+import park.brothers.runwith_back.domain.Action.entity.Action;
+import park.brothers.runwith_back.domain.Action.repository.ActionRepository;
 import park.brothers.runwith_back.domain.Belong.dto.Request.ChangeLeaderRequestDto;
 import park.brothers.runwith_back.domain.Belong.dto.Request.CreateBelongRequestDto;
 import park.brothers.runwith_back.domain.Belong.dto.Response.CreateBelongResponseDto;
@@ -16,6 +18,8 @@ import park.brothers.runwith_back.domain.Group.entity.Group;
 import park.brothers.runwith_back.domain.Group.repository.GroupRepository;
 import park.brothers.runwith_back.domain.Runner.entity.Runner;
 import park.brothers.runwith_back.domain.Runner.repository.RunnerRepository;
+import park.brothers.runwith_back.domain.Schedule.entity.Schedule;
+import park.brothers.runwith_back.domain.Schedule.repository.ScheduleRepository;
 import park.brothers.runwith_back.external.AWS_S3.AWSS3Service;
 
 import java.util.List;
@@ -30,6 +34,8 @@ public class Version1BelongService implements BelongService{
     private final BelongRepository belongRepository;
     private final RunnerRepository runnerRepository;
     private final GroupRepository groupRepository;
+    private final ScheduleRepository scheduleRepository;
+    private final ActionRepository actionRepository;
     private final AWSS3Service aWSS3Service;
 
     // 그룹 참여
@@ -84,6 +90,19 @@ public class Version1BelongService implements BelongService{
         //러너가 그룹에 속하지 않을 때
         if(foundBelong.isEmpty()){
             throw new ResourceNotFoundException("해당 러너는 이 그룹에 속하지 않습니다.");
+        }
+
+        //그룹에서 생성된 Schedule 추출
+        List<Schedule> schedules = scheduleRepository.findByBelongId(foundBelong.get().getId());
+
+        //스케줄로부터 생성된 모든 Actions들 삭제
+        for(Schedule schedule : schedules){
+            List<Action> actions = actionRepository.findActionsByScheduleId(schedule.getId());
+            for(Action action : actions){
+                actionRepository.delete(action);
+            }
+            //actions들 삭제 다 하면 schedule를 삭제
+            scheduleRepository.delete(schedule);
         }
 
         belongRepository.deleteByRunnerIdAndGroupId(runnerId, groupUUID);

--- a/src/main/java/park/brothers/runwith_back/domain/Group/repository/JPAGroupRepository.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Group/repository/JPAGroupRepository.java
@@ -2,7 +2,6 @@ package park.brothers.runwith_back.domain.Group.repository;
 
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/park/brothers/runwith_back/domain/Group/repository/JPAGroupRepository.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Group/repository/JPAGroupRepository.java
@@ -13,21 +13,22 @@ import java.util.Optional;
 import java.util.UUID;
 
 @Repository
-@Slf4j
 @Primary
-@Transactional
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class JPAGroupRepository implements GroupRepository {
 
     private final EntityManager em;
 
     @Override
+    @Transactional
     public Group save(Group group) {
         em.persist(group);
         return group;
     }
 
     @Override
+    @Transactional
     public void delete(Group group) {
         em.remove(group);
     }
@@ -80,6 +81,7 @@ public class JPAGroupRepository implements GroupRepository {
 
     //그룹 정보 수정
     @Override
+    @Transactional
     public Group revise(Group group, String groupDescription, int groupCertificationCriteria) {
         if(groupDescription != null){
             group.setDescription(groupDescription);

--- a/src/main/java/park/brothers/runwith_back/domain/Group/service/Version1GroupService.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Group/service/Version1GroupService.java
@@ -2,6 +2,7 @@ package park.brothers.runwith_back.domain.Group.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import park.brothers.runwith_back.common.Exceptions.ResourceNotFoundException;
 import park.brothers.runwith_back.domain.Belong.entity.Belong;
@@ -25,6 +26,7 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class Version1GroupService implements GroupService {
 
     private final GroupRepository groupRepository;
@@ -33,6 +35,7 @@ public class Version1GroupService implements GroupService {
     private final AWSS3Service awss3Service;
 
     @Override
+    @Transactional
     public CreateGroupResponseDto save(String runnerId, CreateGroupRequestDto createGroupRequestDto, MultipartFile image) throws IllegalAccessError, IOException {
         //이미 존재하는 그룹 이름인지 확인하기
         Optional<Group> existGroup = groupRepository.findByName(createGroupRequestDto.getGroupName());
@@ -115,6 +118,7 @@ public class Version1GroupService implements GroupService {
 
 
     @Override
+    @Transactional
     public void delete(String runnerId, String groupId) {
         UUID groupUUID = UUID.fromString(groupId);
 
@@ -149,6 +153,7 @@ public class Version1GroupService implements GroupService {
 
     //그룹 정보 수정
     @Override
+    @Transactional
     public ReviseGroupResponseDto reviseGroup(String runnerId, String groupId, ReviseGroupRequestDto reviseGroupRequestDto, MultipartFile image) throws IllegalAccessError, IOException {
         Optional<Group> group = groupRepository.findById(UUID.fromString(groupId));
         //그룹이 없으면 에러

--- a/src/main/java/park/brothers/runwith_back/domain/JoinRequest/repository/JPAJoinRequestRepository.java
+++ b/src/main/java/park/brothers/runwith_back/domain/JoinRequest/repository/JPAJoinRequestRepository.java
@@ -2,7 +2,6 @@ package park.brothers.runwith_back.domain.JoinRequest.repository;
 
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/park/brothers/runwith_back/domain/JoinRequest/repository/JPAJoinRequestRepository.java
+++ b/src/main/java/park/brothers/runwith_back/domain/JoinRequest/repository/JPAJoinRequestRepository.java
@@ -13,9 +13,8 @@ import java.util.Optional;
 import java.util.UUID;
 
 @Repository
-@Slf4j
 @Primary
-@Transactional
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class JPAJoinRequestRepository implements JoinRequestRepository {
 
@@ -43,6 +42,7 @@ public class JPAJoinRequestRepository implements JoinRequestRepository {
 
     //저장하기
     @Override
+    @Transactional
     public JoinRequest save(JoinRequest newJoinRequest) {
         em.persist(newJoinRequest);
         return newJoinRequest;
@@ -50,6 +50,7 @@ public class JPAJoinRequestRepository implements JoinRequestRepository {
 
     //삭제하기
     @Override
+    @Transactional
     public void delete(JoinRequest joinRequest) {
         em.remove(joinRequest);
     }

--- a/src/main/java/park/brothers/runwith_back/domain/JoinRequest/service/Version1JoinRequestService.java
+++ b/src/main/java/park/brothers/runwith_back/domain/JoinRequest/service/Version1JoinRequestService.java
@@ -2,6 +2,7 @@ package park.brothers.runwith_back.domain.JoinRequest.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import park.brothers.runwith_back.common.Exceptions.NotAcceptableException;
 import park.brothers.runwith_back.common.Exceptions.ResourceNotFoundException;
 import park.brothers.runwith_back.common.Exceptions.UnauthorizedException;
@@ -25,6 +26,7 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class Version1JoinRequestService implements JoinRequestService {
 
     private final BelongRepository belongRepository;
@@ -34,6 +36,7 @@ public class Version1JoinRequestService implements JoinRequestService {
 
     //그룹 가입 신청 생성하기
     @Override
+    @Transactional
     public CreateJoinRequestResponseDto save(String runnerId, CreateJoinRequestRequestDto createJoinRequestRequestDto) {
         //러너가 존재하지 않으면 안됨
         Optional<Runner> runner = runnerRepository.findById(runnerId);
@@ -78,6 +81,7 @@ public class Version1JoinRequestService implements JoinRequestService {
 
     //그룹 가입 신청 철회
     @Override
+    @Transactional
     public void delete(String runnerId, String joinRequestId) {
         UUID joinRequestUUID = UUID.fromString(joinRequestId);
         Optional<JoinRequest> joinRequest = joinRequestRepository.findById(joinRequestUUID);
@@ -103,6 +107,7 @@ public class Version1JoinRequestService implements JoinRequestService {
 
     //그룹 가입 신청 승인
     @Override
+    @Transactional
     public void accept(String runnerId, String joinRequestId) {
         UUID joinRequestUUID = UUID.fromString(joinRequestId);
         Optional<JoinRequest> joinRequest = joinRequestRepository.findById(joinRequestUUID);
@@ -141,6 +146,7 @@ public class Version1JoinRequestService implements JoinRequestService {
 
     // 그룹 가입 신청 거부
     @Override
+    @Transactional
     public void reject(String runnerId, String joinRequestId) {
         UUID joinRequestUUID = UUID.fromString(joinRequestId);
         Optional<JoinRequest> joinRequest = joinRequestRepository.findById(joinRequestUUID);

--- a/src/main/java/park/brothers/runwith_back/domain/Recognize/repository/JPARecognizeRepository.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Recognize/repository/JPARecognizeRepository.java
@@ -13,9 +13,8 @@ import java.util.Optional;
 import java.util.UUID;
 
 @Repository
-@Slf4j
 @Primary
-@Transactional
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class JPARecognizeRepository implements RecognizeRepository {
 
@@ -23,6 +22,7 @@ public class JPARecognizeRepository implements RecognizeRepository {
 
     //recognize 객체 저장
     @Override
+    @Transactional
     public Recognize save(Recognize recognize) {
         em.persist(recognize);
         return recognize;
@@ -30,6 +30,7 @@ public class JPARecognizeRepository implements RecognizeRepository {
 
     //인정 여부 수정
     @Override
+    @Transactional
     public Recognize revise(Recognize recognize, boolean recognizing) {
         recognize.setRecognizing(recognizing);
         return recognize;
@@ -47,6 +48,7 @@ public class JPARecognizeRepository implements RecognizeRepository {
 
     //Recognize삭제
     @Override
+    @Transactional
     public void delete(Recognize recognize) {
         em.remove(recognize);
     }
@@ -72,6 +74,7 @@ public class JPARecognizeRepository implements RecognizeRepository {
 
     //스케줄 id를 가진 recognize 전체 삭제
     @Override
+    @Transactional
     public void deleteByScheduleId(UUID scheduleId) {
         em.createQuery("delete from Recognize r where r.recognizedSchedule.id = :scheduleId")
             .setParameter("scheduleId", scheduleId)

--- a/src/main/java/park/brothers/runwith_back/domain/Recognize/repository/JPARecognizeRepository.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Recognize/repository/JPARecognizeRepository.java
@@ -2,7 +2,6 @@ package park.brothers.runwith_back.domain.Recognize.repository;
 
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/park/brothers/runwith_back/domain/Recognize/repository/JPARecognizeRepository.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Recognize/repository/JPARecognizeRepository.java
@@ -69,4 +69,12 @@ public class JPARecognizeRepository implements RecognizeRepository {
                 .getResultStream()
                 .findFirst();
     }
+
+    //스케줄 id를 가진 recognize 전체 삭제
+    @Override
+    public void deleteByScheduleId(UUID scheduleId) {
+        em.createQuery("delete from Recognize r where r.recognizedSchedule.id = :scheduleId")
+            .setParameter("scheduleId", scheduleId)
+            .executeUpdate();
+    }
 }

--- a/src/main/java/park/brothers/runwith_back/domain/Recognize/repository/RecognizeRepository.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Recognize/repository/RecognizeRepository.java
@@ -19,4 +19,6 @@ public interface RecognizeRepository {
     List<Recognize> findByScheduleId(UUID scheduleId);
 
     Optional<Recognize> findByRunnerIdAndScheduleId(String runnerId, UUID scheduleId);
+
+    void deleteByScheduleId(UUID scheduleId);
 }

--- a/src/main/java/park/brothers/runwith_back/domain/Recognize/service/Version1RecognizeService.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Recognize/service/Version1RecognizeService.java
@@ -2,6 +2,7 @@ package park.brothers.runwith_back.domain.Recognize.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import park.brothers.runwith_back.common.Exceptions.NotAcceptableException;
 import park.brothers.runwith_back.common.Exceptions.ResourceNotFoundException;
 import park.brothers.runwith_back.common.Exceptions.UnauthorizedException;
@@ -21,6 +22,7 @@ import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class Version1RecognizeService implements RecognizeService {
 
     private final RunnerRepository runnerRepository;
@@ -29,6 +31,7 @@ public class Version1RecognizeService implements RecognizeService {
     private final RecognizeRepository recognizeRepository;
 
     @Override
+    @Transactional
     public ChangeRecognizeResponseDto changeRecognize(String runnerId, ChangeRecognizeRequestDto changeRecognizeRequestDto, String scheduleId) {
         // runner가 존재해야 함
         Optional<Runner> runner = runnerRepository.findById(runnerId);

--- a/src/main/java/park/brothers/runwith_back/domain/Runner/repository/JPARunnerRepository.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Runner/repository/JPARunnerRepository.java
@@ -11,7 +11,6 @@ import park.brothers.runwith_back.domain.Runner.entity.Runner;
 import java.util.*;
 
 @Repository
-@Slf4j
 @Primary
 @Transactional
 @RequiredArgsConstructor
@@ -48,6 +47,7 @@ public class JPARunnerRepository implements RunnerRepository {
 
     //러너 정보 수정
     @Override
+    @Transactional
     public void reviseRunner(Runner runner, String runnerName) {
         runner.setName(runnerName);
     }

--- a/src/main/java/park/brothers/runwith_back/domain/Runner/repository/JPARunnerRepository.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Runner/repository/JPARunnerRepository.java
@@ -2,7 +2,6 @@ package park.brothers.runwith_back.domain.Runner.repository;
 
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/park/brothers/runwith_back/domain/Runner/service/Version1RunnerService.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Runner/service/Version1RunnerService.java
@@ -2,6 +2,7 @@ package park.brothers.runwith_back.domain.Runner.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import park.brothers.runwith_back.common.Exceptions.ResourceNotFoundException;
 import park.brothers.runwith_back.domain.Belong.entity.Belong;
@@ -21,6 +22,7 @@ import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class Version1RunnerService implements RunnerService {
 
     private final RunnerRepository runnerRepository;
@@ -30,6 +32,7 @@ public class Version1RunnerService implements RunnerService {
     private final AWSS3Service awss3Service;
 
     @Override
+    @Transactional
     public CreateRunnerResponseDto save(String runnerId, CreateRunnerRequestDto createRunnerRequestDto, MultipartFile image) throws IllegalAccessError, IOException {
         //러너 생성
         Runner runner = new Runner();

--- a/src/main/java/park/brothers/runwith_back/domain/Schedule/repository/JpaScheduleRepository.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Schedule/repository/JpaScheduleRepository.java
@@ -15,9 +15,9 @@ import java.util.Optional;
 import java.util.UUID;
 
 @Repository
-@Slf4j
 @Primary
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class JpaScheduleRepository implements ScheduleRepository{
 
     private final EntityManager em;

--- a/src/main/java/park/brothers/runwith_back/domain/Schedule/repository/JpaScheduleRepository.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Schedule/repository/JpaScheduleRepository.java
@@ -3,7 +3,6 @@ package park.brothers.runwith_back.domain.Schedule.repository;
 
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/park/brothers/runwith_back/domain/Schedule/service/Version1ScheduleService.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Schedule/service/Version1ScheduleService.java
@@ -5,6 +5,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import park.brothers.runwith_back.common.Exceptions.ResourceNotFoundException;
 import park.brothers.runwith_back.common.Exceptions.UnauthorizedException;
+import park.brothers.runwith_back.domain.Action.entity.Action;
+import park.brothers.runwith_back.domain.Action.repository.ActionRepository;
 import park.brothers.runwith_back.domain.Belong.entity.Belong;
 import park.brothers.runwith_back.domain.Belong.repository.BelongRepository;
 import park.brothers.runwith_back.domain.Recognize.entity.Recognize;
@@ -30,6 +32,7 @@ import java.util.stream.Collectors;
 public class Version1ScheduleService implements ScheduleService{
     private final ScheduleRepository scheduleRepository;
     private final BelongRepository belongRepository;
+    private final ActionRepository actionRepository;
     private final RecognizeRepository recognizeRepository;
 
     //스케줄 생성
@@ -82,8 +85,14 @@ public class Version1ScheduleService implements ScheduleService{
 
         //해당 스케줄 id를 인정한 기록 삭제
         List<Recognize> recognizes = recognizeRepository.findByScheduleId(schedule.get().getId());
-        for(Recognize r: recognizes){
-            recognizeRepository.delete(r);
+        for(Recognize recognize: recognizes){
+            recognizeRepository.delete(recognize);
+        }
+
+        //해당 스케줄을 FK로 가진 Actions들 삭제
+        List<Action> actions = actionRepository.findActionsByScheduleId(schedule.get().getId());
+        for(Action action : actions){
+            actionRepository.delete(action);
         }
 
         scheduleRepository.delete(schedule.get());

--- a/src/main/java/park/brothers/runwith_back/domain/Schedule/service/Version1ScheduleService.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Schedule/service/Version1ScheduleService.java
@@ -1,7 +1,6 @@
 package park.brothers.runwith_back.domain.Schedule.service;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import park.brothers.runwith_back.common.Exceptions.ResourceNotFoundException;

--- a/src/main/java/park/brothers/runwith_back/domain/Schedule/service/Version1ScheduleService.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Schedule/service/Version1ScheduleService.java
@@ -3,6 +3,7 @@ package park.brothers.runwith_back.domain.Schedule.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import park.brothers.runwith_back.common.Exceptions.ResourceNotFoundException;
 import park.brothers.runwith_back.common.Exceptions.UnauthorizedException;
 import park.brothers.runwith_back.domain.Action.repository.ActionRepository;
@@ -25,9 +26,9 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-@Slf4j
 @RequiredArgsConstructor
 @Service
+@Transactional(readOnly = true)
 public class Version1ScheduleService implements ScheduleService{
     private final ScheduleRepository scheduleRepository;
     private final BelongRepository belongRepository;
@@ -36,6 +37,7 @@ public class Version1ScheduleService implements ScheduleService{
 
     //스케줄 생성
     @Override
+    @Transactional
     public CreateScheduleResponseDto create(String runnerId, CreateScheduleRequestDto createScheduleRequestDto) {
         //비어있는 belong인지 확인
         Optional<Belong> belong = belongRepository.findById(UUID.fromString(createScheduleRequestDto.getBelongId()));
@@ -69,6 +71,7 @@ public class Version1ScheduleService implements ScheduleService{
 
     //스케줄 삭제
     @Override
+    @Transactional
     public void delete(String runnerId, String scheduleId) {
         Optional<Schedule> schedule = scheduleRepository.findScheduleById(UUID.fromString(scheduleId));
 
@@ -123,6 +126,7 @@ public class Version1ScheduleService implements ScheduleService{
 
     //특정 스케줄 수정
     @Override
+    @Transactional
     public ReviseScheduleResponseDto revise(String runnerId, String scheduleId, ReviseScheduleRequestDto reviseScheduleRequestDto) {
         Optional<Schedule> schedule = scheduleRepository.findScheduleById(UUID.fromString(scheduleId));
         //비어있는 스케줄인지 확인

--- a/src/main/java/park/brothers/runwith_back/domain/Schedule/service/Version1ScheduleService.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Schedule/service/Version1ScheduleService.java
@@ -84,17 +84,12 @@ public class Version1ScheduleService implements ScheduleService{
         }
 
         //해당 스케줄 id를 인정한 기록 삭제
-        List<Recognize> recognizes = recognizeRepository.findByScheduleId(schedule.get().getId());
-        for(Recognize recognize: recognizes){
-            recognizeRepository.delete(recognize);
-        }
+        recognizeRepository.deleteByScheduleId(schedule.get().getId());
 
         //해당 스케줄을 FK로 가진 Actions들 삭제
-        List<Action> actions = actionRepository.findActionsByScheduleId(schedule.get().getId());
-        for(Action action : actions){
-            actionRepository.delete(action);
-        }
+        actionRepository.deleteByScheduleId(schedule.get().getId());
 
+        //스케줄 삭제
         scheduleRepository.delete(schedule.get());
     }
 

--- a/src/main/java/park/brothers/runwith_back/domain/Schedule/service/Version1ScheduleService.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Schedule/service/Version1ScheduleService.java
@@ -5,7 +5,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import park.brothers.runwith_back.common.Exceptions.ResourceNotFoundException;
 import park.brothers.runwith_back.common.Exceptions.UnauthorizedException;
-import park.brothers.runwith_back.domain.Action.entity.Action;
 import park.brothers.runwith_back.domain.Action.repository.ActionRepository;
 import park.brothers.runwith_back.domain.Belong.entity.Belong;
 import park.brothers.runwith_back.domain.Belong.repository.BelongRepository;


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 빌롱, 스케줄 삭제 시 FK로 연결된 스케줄/액션/참여요청 데이터 삭제

- repository에 deleteById 메서드 생성으로 한번에 삭제하도록 함

- Transactional 적용
1. 모든 서비스, 레퍼지토리 단에 Transactional(readOnly=True) 적용
2. C U D 메서드에 Transactional 적용
