### PR TITLE
[hotfix] 사진 존재하지 않을 시 러너 수정이 되지 않는 오류 수정

### DIFF
--- a/src/main/java/park/brothers/runwith_back/domain/Runner/service/Version1RunnerService.java
+++ b/src/main/java/park/brothers/runwith_back/domain/Runner/service/Version1RunnerService.java
@@ -91,6 +91,7 @@ public class Version1RunnerService implements RunnerService {
         );
     }
 
+    //러너 수정 서비스
     @Override
     public GetMyInfoResponseDto revise(String runnerId, ReviseMyInfoRequestDto reviseMyInfoRequestDto, MultipartFile image) throws IOException {
         Optional<Runner> runner = runnerRepository.findById(runnerId);
@@ -109,17 +110,14 @@ public class Version1RunnerService implements RunnerService {
         }
 
         //이미지가 비어있지 않다면 이미지 수정
-        String imageLink;
-        if(!image.isEmpty()){
-            imageLink = awss3Service.putImageToAWSS3(image, "runners", runnerId, 0);
-        } else {
-            imageLink = awss3Service.getImagePresignedUrl("runners", runnerId, 0);
-        }
+        String presignedImageUrl = (image != null && !image.isEmpty())
+                ? awss3Service.putImageToAWSS3(image, "runners", runnerId, 0)
+                : awss3Service.getImagePresignedUrl("runners", runnerId, 0);
 
 
         return new GetMyInfoResponseDto(
                 runnerName,
-                imageLink
+                presignedImageUrl
         );
 
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
hotfix : 러너 수정 되지 않는 오류

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
수정할 러너의 이미지가 없는 경우, null 임에도 isEmpty()로 접근하려고 하여 오류가 발생
-> 로직에 null 인지 확인하는 조건문 추가